### PR TITLE
Semver checking + fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  build:
+  test:
     strategy:
       matrix:
         toolchain: [stable, beta, nightly]
@@ -74,3 +74,19 @@ jobs:
         path: |
           target/cargo-timings/cargo-timing-*.html
 
+  semver:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3.1.0
+
+    - uses: Swatinem/rust-cache@v2.0.2
+
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v1
+      # Use workspace target dir for cargo install's build, so that the build will be cached.
+      env:
+        CARGO_TARGET_DIR: target/
+      with:
+        crate-name: exhaust
+        version-tag-prefix: v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "exhaust"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 # TODO: figure out MSRV
 description = "Trait and derive macro for working with all possible values of a type (exhaustive enumeration)."
@@ -21,7 +21,7 @@ std = ["alloc"]
 alloc = ["itertools"]
 
 [dependencies]
-exhaust-macros = { version = "0.1.0", path = "exhaust-macros" }
+exhaust-macros = { version = "0.1.1", path = "exhaust-macros" }
 paste = "1.0.5"
 # itertools is used for its powerset iterator, which is only available with alloc
 itertools = { version = "0.10.3", optional = true, default-features = false, features = ["use_alloc"] }

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exhaust-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Proc-macro support for the 'exhaust' library."
 repository = "https://github.com/kpreid/exhaust/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub use exhaust_macros::Exhaust;
 pub(crate) mod patterns;
 
 pub mod impls;
+/// Reexport for compatibility with v0.1.0;
+/// new code should use [`impls::ExhaustArray`](ExhaustArray).
+pub use impls::ExhaustArray;
 
 mod convenience;
 pub use convenience::*;


### PR DESCRIPTION
This PR does three things:

* Add [`cargo-semver-checks`](https://crates.io/crates/cargo-semver-checks) CI
* Bump the version from 0.1.0 to 0.1.1 (because cargo-semver-checks wants to see a future version number, not one identical to last release)
* Fix a semver incompatibility by reexporting `ExhaustArray` (I'll take it out again on a major release)