### PR TITLE
Implement `Exhaust` for `Cow`, `Poll`, `BuildHasherDefault`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     * `core::cmp::Ordering`
     * `core::future::Pending`
     * `core::future::Ready`
+    * `core::hash::BuildHasherDefault`
     * `core::iter::Reverse`
     * `core::marker::PhantomPinned`
     * `core::num::FpCategory`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     * `core::num::FpCategory`
     * `core::num::NonZero*`
     * `core::result::Result`
+    * `core::task::Poll`
     * `alloc::collections::BTreeMap`
     * `alloc::collections::BTreeSet`
         * Note: Does not produce lexicographic ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     * `core::num::NonZero*`
     * `core::result::Result`
     * `core::task::Poll`
+    * `alloc::borrow::Cow`
     * `alloc::collections::BTreeMap`
     * `alloc::collections::BTreeSet`
         * Note: Does not produce lexicographic ordering.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ default = ["std"]
 std = ["alloc"]
 alloc = ["itertools"]
 
+[[test]]
+name = "alloc_impls"
+required-features = ["alloc"]
+
 [dependencies]
 exhaust-macros = { version = "0.1.1", path = "exhaust-macros" }
 paste = "1.0.5"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -15,6 +15,9 @@
 //! * [`u64`], [`i64`], and [`f64`], because they are too large to feasibly exhaust.
 //! * [`core::cell::UnsafeCell`], because it does not implement [`Clone`].
 //! * [`core::mem::ManuallyDrop`], because it would be a memory leak.
+//! * [`core::mem::MaybeUninit`], because it is not useful to obtain a `MaybeUninit<T>`
+//!   value without knowing whether it is initialized, and if they are to be all
+//!   initialized, then `T::exhaust()` is just as good.
 //! * [`alloc::vec::Vec`] and other collections that permit duplicate items, since their
 //!   possible values are bounded only by available memory.
 //! * [`std::io::ErrorKind`] and other explicitly non-exhaustive types.
@@ -52,7 +55,6 @@ mod std_impls;
 //   core::lazy::* (not yet stabilized)
 //   core::fmt::Alignment
 //   core::fmt::Error (do we want to impl for Error types in general?)
-//   core::mem::MaybeUninit
 //   core::ops::{Bound, ControlFlow, Range*}
 //   core::sync::atomic::*
 //   alloc::collections::BinaryHeap

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -37,6 +37,7 @@ mod core_primitive;
 pub use core_primitive::*;
 mod core_result;
 pub use core_result::*;
+mod core_task;
 
 #[cfg(feature = "alloc")]
 mod alloc_impls;
@@ -54,7 +55,6 @@ mod std_impls;
 //   core::mem::MaybeUninit
 //   core::ops::{Bound, ControlFlow, Range*}
 //   core::sync::atomic::*
-//   core::task::Poll
 //   alloc::borrow::Cow (with the caveat of no Borroweds)
 //   alloc::collections::BinaryHeap
 //   std::collections::HashMap (generalize the BTreeMap implementation)

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -55,7 +55,6 @@ mod std_impls;
 //   core::mem::MaybeUninit
 //   core::ops::{Bound, ControlFlow, Range*}
 //   core::sync::atomic::*
-//   alloc::borrow::Cow (with the caveat of no Borroweds)
 //   alloc::collections::BinaryHeap
 //   std::collections::HashMap (generalize the BTreeMap implementation)
 //   std::io::{BufReader, BufWriter, Sink}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -28,6 +28,7 @@ mod core_cell;
 mod core_cmp;
 mod core_convert;
 mod core_future;
+mod core_hash;
 mod core_marker;
 mod core_num;
 pub use core_num::*;
@@ -48,7 +49,6 @@ mod std_impls;
 // TODO: The following implementations might be missing:
 //   core::iter::* (combinatorial explosion fun!)
 //     Iterators for std library types *not* in core::iter
-//   core::hash::*
 //   core::lazy::* (not yet stabilized)
 //   core::fmt::Alignment
 //   core::fmt::Error (do we want to impl for Error types in general?)

--- a/src/impls/core_hash.rs
+++ b/src/impls/core_hash.rs
@@ -1,0 +1,13 @@
+use core::hash;
+use core::iter;
+
+use crate::Exhaust;
+
+impl<H> Exhaust for hash::BuildHasherDefault<H> {
+    type Iter = iter::Once<hash::BuildHasherDefault<H>>;
+
+    fn exhaust() -> Self::Iter {
+        // `BuildHasherDefault` is a ZST; it has exactly one value.
+        iter::once(hash::BuildHasherDefault::default())
+    }
+}

--- a/src/impls/core_task.rs
+++ b/src/impls/core_task.rs
@@ -1,0 +1,19 @@
+use core::iter;
+use core::task;
+
+use crate::Exhaust;
+
+impl<T: Exhaust> Exhaust for task::Poll<T> {
+    type Iter = iter::Map<<Option<T> as Exhaust>::Iter, fn(Option<T>) -> task::Poll<T>>;
+
+    fn exhaust() -> Self::Iter {
+        Option::<T>::exhaust().map(option_to_poll as _)
+    }
+}
+
+fn option_to_poll<T>(opt: Option<T>) -> task::Poll<T> {
+    match opt {
+        None => task::Poll::Pending,
+        Some(val) => task::Poll::Ready(val),
+    }
+}

--- a/tests/alloc_impls.rs
+++ b/tests/alloc_impls.rs
@@ -1,0 +1,16 @@
+extern crate alloc;
+use alloc::borrow::Cow;
+
+use exhaust::Exhaust;
+
+fn c<T: Exhaust>() -> Vec<T> {
+    T::exhaust().collect()
+}
+
+#[test]
+fn impl_cow() {
+    assert_eq!(
+        c::<Cow<'_, bool>>(),
+        vec![Cow::Owned(false), Cow::Owned(true)]
+    );
+}

--- a/tests/core_impls.rs
+++ b/tests/core_impls.rs
@@ -153,6 +153,15 @@ fn impl_option() {
 }
 
 #[test]
+fn impl_poll() {
+    use core::task::Poll;
+    assert_eq!(
+        c::<Poll<bool>>(),
+        vec![Poll::Pending, Poll::Ready(false), Poll::Ready(true)]
+    );
+}
+
+#[test]
 fn impl_result() {
     assert_eq!(
         c::<Result<bool, bool>>(),


### PR DESCRIPTION
Just working through the list of missing implementations. Also decline to implement for `MaybeUninit`, which seems more hazardous than useful.

