### PR TITLE
CI: Use direct-minimal-versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,15 @@ jobs:
       # Install exactly what we need: compiler, Cargo, clippy, rustfmt
       run: |
           rustup toolchain install "${{ matrix.toolchain }}" --profile=minimal --component=clippy --component=rustfmt
+          rustup toolchain install nightly --profile=minimal
           rustup override set "${{ matrix.toolchain }}"
 
     # Load cache before doing any Rust builds
     - uses: Swatinem/rust-cache@v2.7.1
+
+    # The repository does not have a versioned Cargo.lock file.
+    # As a substitute, we always test on minimal and maximal versions.
+    - run: cargo +nightly update -Zdirect-minimal-versions
 
     - name: Lint
       run: |
@@ -57,13 +62,17 @@ jobs:
     - name: Run tests (all features)
       run: cargo test --all-features
 
-    - name: Update
+    # Test with latest deps, but only if we can.
+    # TODO: Once Cargo has the MSRV-aware resolver, this `if` will be unnecessary.
+    - if: ${{ matrix.toolchain != '1.60.0' }}
       run: cargo update
 
     - name: Compile with updates
+      if: ${{ matrix.toolchain != '1.60.0' }}
       run: cargo test --timings --no-run
 
     - name: Test with updates
+      if: ${{ matrix.toolchain != '1.60.0' }}
       run: cargo test --timings
 
     # Save timing reports so we can download and view them

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
+proc-macro2 = "1.0.86"
+quote = "1.0.37"
 syn = { version = "2.0.13", features = ["full"] }
 itertools = "0.10.3"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,5 +10,5 @@ name = "xtask"
 path = "src/xtask.rs"
 
 [dependencies]
-clap = { version = "3.0.8", default-features = false, features = ["derive", "std", "suggestions"] }
+clap = { version = "3.2.23", default-features = false, features = ["derive", "std", "suggestions"] }
 xaction = "0.2.4"


### PR DESCRIPTION
This should fix the test build for 1.60.0 and also make the "Test with updates" step actually do something; it did not because the Cargo.lock file is not versioned, so the first build would always be freshly updated anyway.