### PR TITLE
Deps: Update `itertools` to 0.13.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["exhaustive"]
 [features]
 default = ["std"]
 std = ["alloc"]
-alloc = ["itertools"]
+alloc = ["dep:itertools"]
 
 [[test]]
 name = "alloc_impls"
@@ -30,6 +30,14 @@ required-features = ["std"]
 
 [dependencies]
 exhaust-macros = { version = "0.1.1", path = "exhaust-macros" }
-paste = "1.0.5"
 # itertools is used for its powerset iterator, which is only available with alloc
-itertools = { version = "0.12.0", optional = true, default-features = false, features = ["use_alloc"] }
+itertools = { workspace = true, optional = true }
+paste = "1.0.5"
+
+[workspace.dependencies]
+# Note!!! It would be nice if we could use a wide range of itertools versions,
+# but there is a bug fixed in 0.13.0, <https://github.com/rust-itertools/itertools/issues/337>,
+# which affects `ExhaustHashMap` and `ExhaustBTreeMap`, so it actually matters that we have 0.13.0
+# here. But when 0.14.0 is released, consider changing this to `>=0.13.0, <0.15.0` so that we can
+# allow dependents to stay off the upgrade treadmill without duplicating versions.
+itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
+itertools = { workspace = true }
 proc-macro2 = "1.0.86"
 quote = "1.0.37"
 syn = { version = "2.0.13", features = ["full"] }
-itertools = "0.10.3"

--- a/src/impls/alloc_impls.rs
+++ b/src/impls/alloc_impls.rs
@@ -86,12 +86,7 @@ impl<K: Exhaust + Ord, V: Exhaust> Iterator for ExhaustBTreeMap<K, V> {
     type Item = BTreeMap<K, V>;
     fn next(&mut self) -> Option<Self::Item> {
         let keys: BTreeSet<K> = self.keys.peek()?.clone();
-        let vals: Vec<V> = if keys.is_empty() {
-            // Empty sets have no keys and therefore no value iterator elements
-            Vec::new()
-        } else {
-            self.vals.next()?
-        };
+        let vals: Vec<V> = self.vals.next()?;
 
         if self.vals.peek().is_none() {
             self.keys.next();

--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -113,12 +113,7 @@ where
     type Item = HashMap<K, V, S>;
     fn next(&mut self) -> Option<Self::Item> {
         let keys: HashSet<K, S> = self.keys.peek()?.clone();
-        let vals: Vec<V> = if keys.is_empty() {
-            // Empty sets have no keys and therefore no value iterator elements
-            Vec::new()
-        } else {
-            self.vals.next()?
-        };
+        let vals: Vec<V> = self.vals.next()?;
 
         if self.vals.peek().is_none() {
             self.keys.next();


### PR DESCRIPTION
This allows us to remove a special case which turned out to be a bug workaround.

I also switched to workspace dependencies for `itertools` so that we don't accidentally have dependencies on two different versions again.