### PR TITLE
Add `Factory` and remove `Clone` bound on Exhaust (breaking change).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly, 1.60.0]
+        toolchain: [stable, beta, nightly, 1.80.0]
 
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
@@ -61,15 +61,15 @@ jobs:
 
     # Test with latest deps, but only if we can.
     # TODO: Once Cargo has the MSRV-aware resolver, this `if` will be unnecessary.
-    - if: ${{ matrix.toolchain != '1.60.0' }}
+    - if: ${{ matrix.toolchain != '1.80.0' }}
       run: cargo update
 
     - name: Compile with updates
-      if: ${{ matrix.toolchain != '1.60.0' }}
+      if: ${{ matrix.toolchain != '1.80.0' }}
       run: cargo test --timings --no-run
 
     - name: Test with updates
-      if: ${{ matrix.toolchain != '1.60.0' }}
+      if: ${{ matrix.toolchain != '1.80.0' }}
       run: cargo test --timings
 
     # Save timing reports so we can download and view them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ However, it may be possible to simplify the iterator by moving some code into `f
 * The minimum supported Rust version is now 1.80.
 * **Breaking:** The derive macro `derive(Exhaust)` now hides its generated items.
   They can only be accessed through the trait implementation’s associated types.
+* **Breaking:** `Exhaust::Iter` types now must implement `FusedIterator`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ However, it may be possible to simplify the iterator by moving some code into `f
 
 * `<Option<T> as Exhaust>::Iter` no longer implements `DoubleEndedIterator`.
   This might be added back in the future.
+* Removed `exhaust::ExhaustArray` from the crate root.
 
 ## 0.1.2 (2024-09-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ However, it may be possible to simplify the iterator by moving some code into `f
     * `std::io::Stdin`
     * `std::io::Stdout`
 
+* `exhaust::Iter<T>` is a single generic iterator for all `T: Exhaust`.
+  It is now the type returned by `Exhaust::exhaust()`.
+
 ### Changed
 
 * The minimum supported Rust version is now 1.80.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ However, it may be possible to simplify the iterator by moving some code into `f
     * `core::cell::UnsafeCell`
     * `core::sync::AtomicBool`
     * `core::sync::Atomic{U,I}{8,16,32}`
+    * `alloc::borrow::Cow<'_ T>`, when `T` implements only `ToOwned` rather than `Clone`.
     * `std::io::BufReader`
     * `std::io::BufWriter`
     * `std::io::Chain`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,22 @@ Existing implementations may be migrated by adding `type Factory = Self`
 and renaming `fn exhaust()` to `fn exhaust_factories()`.
 However, it may be possible to simplify the iterator by moving some code into `fn from_factory()`.
 
+### Added
+
+* `impl Exhaust for ...`
+    * `core::cell::UnsafeCell`
+    * `core::sync::AtomicBool`
+    * `core::sync::Atomic{U,I}{8,16,32}`
+    * `std::io::BufReader`
+    * `std::io::BufWriter`
+    * `std::io::Chain`
+    * `std::io::LineWriter`
+    * `std::io::Repeat`
+    * `std::io::Sink`
+    * `std::io::Stderr`
+    * `std::io::Stdin`
+    * `std::io::Stdout`
+
 ### Changed
 
 * The minimum supported Rust version is now 1.80.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased 0.2.0 (date TBD)
+
+### Changed
+
+* The minimum supported Rust version is now 1.80.
+
+### Removed
+
+* `<Option<T> as Exhaust>::Iter` no longer implements `DoubleEndedIterator`.
+  This might be added back in the future.
+* Removed `exhaust::ExhaustArray` from the crate root.
+* Removed the public module `exhaust::impls`.
+  The iterators can only be accessed through the trait implementation’s associated types.
+
 ## 0.1.2 (2024-09-18)
 
 There are no changes to functionality in this release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ However, it may be possible to simplify the iterator by moving some code into `f
 * `<Option<T> as Exhaust>::Iter` no longer implements `DoubleEndedIterator`.
   This might be added back in the future.
 * Removed `exhaust::ExhaustArray` from the crate root.
+* Removed the public module `exhaust::impls`.
+  The iterators can only be accessed through the trait implementation’s associated types.
 
 ## 0.1.2 (2024-09-18)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,14 @@ required-features = ["alloc"]
 
 [dependencies]
 exhaust-macros = { version = "0.2.0", path = "exhaust-macros" }
-# itertools is used for its powerset iterator, which is only available with alloc,
-# but which we only use for exhausting set and map types.
-#
+# itertools is used for its powerset iterator, which is only available with alloc
+itertools = { workspace = true, optional = true }
+paste = "1.0.5"
+
+[workspace.dependencies]
 # Note!!! It would be nice if we could use a wide range of itertools versions,
 # but there is a bug fixed in 0.13.0, <https://github.com/rust-itertools/itertools/issues/337>,
 # which affects `ExhaustHashMap` and `ExhaustBTreeMap`, so it actually matters that we have 0.13.0
 # here. But when 0.14.0 is released, consider changing this to `>=0.13.0, <0.15.0` so that we can
 # allow dependents to stay off the upgrade treadmill without duplicating versions.
-itertools = { version = "0.13.0", optional = true, default-features = false, features = ["use_alloc"] }
-paste = "1.0.5"
+itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ members = [
 
 [package]
 name = "exhaust"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.80.0"
 description = "Trait and derive macro for working with all possible values of a type (exhaustive enumeration)."
 repository = "https://github.com/kpreid/exhaust/"
 license = "MIT OR Apache-2.0"
@@ -33,7 +33,7 @@ name = "keyed_collections"
 required-features = ["alloc"]
 
 [dependencies]
-exhaust-macros = { version = "0.1.1", path = "exhaust-macros" }
+exhaust-macros = { version = "0.2.0", path = "exhaust-macros" }
 # itertools is used for its powerset iterator, which is only available with alloc,
 # but which we only use for exhausting set and map types.
 #

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 itertools = { version = "0.13.0", default-features = false }
 proc-macro2 = "1.0.86"
 quote = "1.0.37"
-syn = { version = "2.0.13", features = ["full"] }
+syn = { version = "2.0.73", features = ["full"] }

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exhaust-macros"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "Proc-macro support for the 'exhaust' library."
 repository = "https://github.com/kpreid/exhaust/"

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-itertools = { version = "0.13.0", default-features = false }
+itertools = { workspace = true }
 proc-macro2 = "1.0.86"
 quote = "1.0.37"
 syn = { version = "2.0.73", features = ["full"] }

--- a/exhaust-macros/src/common.rs
+++ b/exhaust-macros/src/common.rs
@@ -115,6 +115,9 @@ impl ExhaustContext {
                 }
             }
 
+            impl #impl_generics ::core::iter::FusedIterator for #iterator_type_name #ty_generics
+            where #augmented_where_predicates {}
+
             impl #impl_generics ::core::default::Default for #iterator_type_name #ty_generics
             where #augmented_where_predicates {
                 fn default() -> Self {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -16,6 +16,7 @@ mod core_marker;
 mod core_num;
 pub use core_num::*;
 mod core_option;
+mod core_sync;
 //  core::pin::Pin is handled separately for each pinnable smart pointer.
 mod core_primitive;
 pub use core_primitive::*;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -14,12 +14,10 @@ mod core_future;
 mod core_hash;
 mod core_marker;
 mod core_num;
-pub use core_num::*;
 mod core_option;
 mod core_sync;
 //  core::pin::Pin is handled separately for each pinnable smart pointer.
 mod core_primitive;
-pub use core_primitive::*;
 mod core_result;
 mod core_task;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -20,7 +20,6 @@ mod core_option;
 mod core_primitive;
 pub use core_primitive::*;
 mod core_result;
-pub use core_result::*;
 mod core_task;
 
 #[cfg(feature = "alloc")]

--- a/src/impls/alloc_impls.rs
+++ b/src/impls/alloc_impls.rs
@@ -1,3 +1,4 @@
+use core::iter::FusedIterator;
 use core::pin::Pin;
 use core::{fmt, iter};
 
@@ -70,6 +71,7 @@ impl<T: Exhaust> Iterator for ExhaustSet<T> {
         self.0.next()
     }
 }
+impl<T: Exhaust> FusedIterator for ExhaustSet<T> {}
 
 impl<T: Exhaust> fmt::Debug for ExhaustSet<T>
 where
@@ -149,6 +151,13 @@ where
 
         Some(keys.into_iter().zip_eq(vals).collect())
     }
+}
+impl<KF, KI, V> FusedIterator for ExhaustMap<KI, V>
+where
+    KI: Iterator<Item = Vec<KF>>,
+    KF: Clone,
+    V: Exhaust,
+{
 }
 
 impl<KI, V> Clone for ExhaustMap<KI, V>

--- a/src/impls/core_cell.rs
+++ b/src/impls/core_cell.rs
@@ -2,4 +2,4 @@ use crate::patterns::impl_newtype_generic;
 
 impl_newtype_generic!(T: [Copy], core::cell::Cell<T>, core::cell::Cell::new);
 impl_newtype_generic!(T: [], core::cell::RefCell<T>, core::cell::RefCell::new);
-// Cannot impl for UnsafeCell because it is not Clone.
+impl_newtype_generic!(T: [], core::cell::UnsafeCell<T>, core::cell::UnsafeCell::new);

--- a/src/impls/core_convert.rs
+++ b/src/impls/core_convert.rs
@@ -4,7 +4,8 @@ use crate::Exhaust;
 
 impl Exhaust for core::convert::Infallible {
     type Iter = iter::Empty<core::convert::Infallible>;
-    fn exhaust() -> Self::Iter {
+    fn exhaust_factories() -> Self::Iter {
         iter::empty()
     }
+    crate::patterns::factory_is_self!();
 }

--- a/src/impls/core_future.rs
+++ b/src/impls/core_future.rs
@@ -5,8 +5,9 @@ use crate::Exhaust;
 
 impl<T> Exhaust for future::Pending<T> {
     type Iter = iter::Once<future::Pending<T>>;
-    fn exhaust() -> Self::Iter {
+    fn exhaust_factories() -> Self::Iter {
         iter::once(future::pending())
     }
+    crate::patterns::factory_is_self!();
 }
 impl_newtype_generic!(T: [], future::Ready<T>, future::ready);

--- a/src/impls/core_future.rs
+++ b/src/impls/core_future.rs
@@ -1,13 +1,6 @@
-use core::{future, iter};
+use core::future;
 
-use crate::patterns::impl_newtype_generic;
-use crate::Exhaust;
+use crate::patterns::{impl_newtype_generic, impl_singleton};
 
-impl<T> Exhaust for future::Pending<T> {
-    type Iter = iter::Once<future::Pending<T>>;
-    fn exhaust_factories() -> Self::Iter {
-        iter::once(future::pending())
-    }
-    crate::patterns::factory_is_self!();
-}
+impl_singleton!([T], future::Pending<T>, future::pending());
 impl_newtype_generic!(T: [], future::Ready<T>, future::ready);

--- a/src/impls/core_hash.rs
+++ b/src/impls/core_hash.rs
@@ -6,8 +6,9 @@ use crate::Exhaust;
 impl<H> Exhaust for hash::BuildHasherDefault<H> {
     type Iter = iter::Once<hash::BuildHasherDefault<H>>;
 
-    fn exhaust() -> Self::Iter {
+    fn exhaust_factories() -> Self::Iter {
         // `BuildHasherDefault` is a ZST; it has exactly one value.
         iter::once(hash::BuildHasherDefault::default())
     }
+    crate::patterns::factory_is_self!();
 }

--- a/src/impls/core_hash.rs
+++ b/src/impls/core_hash.rs
@@ -1,14 +1,5 @@
 use core::hash;
-use core::iter;
 
-use crate::Exhaust;
+use crate::patterns::impl_singleton;
 
-impl<H> Exhaust for hash::BuildHasherDefault<H> {
-    type Iter = iter::Once<hash::BuildHasherDefault<H>>;
-
-    fn exhaust_factories() -> Self::Iter {
-        // `BuildHasherDefault` is a ZST; it has exactly one value.
-        iter::once(hash::BuildHasherDefault::default())
-    }
-    crate::patterns::factory_is_self!();
-}
+impl_singleton!([H], hash::BuildHasherDefault<H>);

--- a/src/impls/core_marker.rs
+++ b/src/impls/core_marker.rs
@@ -4,14 +4,16 @@ use crate::Exhaust;
 
 impl<T: ?Sized> Exhaust for core::marker::PhantomData<T> {
     type Iter = iter::Once<core::marker::PhantomData<T>>;
-    fn exhaust() -> Self::Iter {
+    fn exhaust_factories() -> Self::Iter {
         iter::once(core::marker::PhantomData)
     }
+    crate::patterns::factory_is_self!();
 }
 
 impl Exhaust for core::marker::PhantomPinned {
     type Iter = iter::Once<core::marker::PhantomPinned>;
-    fn exhaust() -> Self::Iter {
+    fn exhaust_factories() -> Self::Iter {
         iter::once(core::marker::PhantomPinned)
     }
+    crate::patterns::factory_is_self!();
 }

--- a/src/impls/core_marker.rs
+++ b/src/impls/core_marker.rs
@@ -1,19 +1,6 @@
-use core::iter;
+use core::marker;
 
-use crate::Exhaust;
+use crate::patterns::impl_singleton;
 
-impl<T: ?Sized> Exhaust for core::marker::PhantomData<T> {
-    type Iter = iter::Once<core::marker::PhantomData<T>>;
-    fn exhaust_factories() -> Self::Iter {
-        iter::once(core::marker::PhantomData)
-    }
-    crate::patterns::factory_is_self!();
-}
-
-impl Exhaust for core::marker::PhantomPinned {
-    type Iter = iter::Once<core::marker::PhantomPinned>;
-    fn exhaust_factories() -> Self::Iter {
-        iter::once(core::marker::PhantomPinned)
-    }
-    crate::patterns::factory_is_self!();
-}
+impl_singleton!([T], marker::PhantomData<T>);
+impl_singleton!([], marker::PhantomPinned);

--- a/src/impls/core_num.rs
+++ b/src/impls/core_num.rs
@@ -31,6 +31,7 @@ macro_rules! impl_nonzero {
                     self.0.next()
                 }
             }
+            impl iter::FusedIterator for [< Exhaust $nzt >] {}
         }
     }
 }

--- a/src/impls/core_num.rs
+++ b/src/impls/core_num.rs
@@ -12,9 +12,11 @@ macro_rules! impl_nonzero {
             impl Exhaust for num::$nzt {
                 type Iter = [< Exhaust $nzt >];
 
-                fn exhaust() -> Self::Iter {
-                    [< Exhaust $nzt >] ($t::exhaust().filter_map(num::$nzt::new))
+                fn exhaust_factories() -> Self::Iter {
+                    [< Exhaust $nzt >] ($t::exhaust_factories().filter_map(num::$nzt::new))
                 }
+
+                crate::patterns::factory_is_self!();
             }
 
             #[doc = concat!("Iterator implementation of `", stringify!($nzt), "::exhaust()`.")]

--- a/src/impls/core_option.rs
+++ b/src/impls/core_option.rs
@@ -1,13 +1,28 @@
-use core::iter;
-
 use crate::Exhaust;
 
 impl<T: Exhaust> Exhaust for Option<T> {
-    #![allow(clippy::type_complexity)] // TODO: use macro to generate an opaque iter
-    type Iter =
-        iter::Chain<iter::Once<Option<T>>, iter::Map<<T as Exhaust>::Iter, fn(T) -> Option<T>>>;
+    type Iter = <remote::Option<T> as Exhaust>::Iter;
+    type Factory = <remote::Option<T> as Exhaust>::Factory;
 
-    fn exhaust() -> Self::Iter {
-        iter::once(None).chain(T::exhaust().map(Some as _))
+    fn exhaust_factories() -> Self::Iter {
+        remote::Option::exhaust_factories()
+    }
+
+    fn from_factory(factory: Self::Factory) -> Self {
+        match remote::Option::from_factory(factory) {
+            remote::Option::None => None,
+            remote::Option::Some(v) => Some(v),
+        }
+    }
+}
+
+/// Like the Serde “remote derive” pattern, we define a type imitating the real type
+/// which the derive macro can process.
+mod remote {
+    #[allow(missing_debug_implementations)] // not actually public
+    #[derive(crate::Exhaust)]
+    pub enum Option<T> {
+        None,
+        Some(T),
     }
 }

--- a/src/impls/core_primitive.rs
+++ b/src/impls/core_primitive.rs
@@ -84,6 +84,7 @@ impl<T: Exhaust, const N: usize> Clone for ExhaustArray<T, N> {
 
 impl<T: Exhaust, const N: usize> Iterator for ExhaustArray<T, N> {
     type Item = [T::Factory; N];
+
     fn next(&mut self) -> Option<Self::Item> {
         if N == 0 {
             return if self.done_zero {
@@ -133,3 +134,5 @@ impl<T: Exhaust, const N: usize> Iterator for ExhaustArray<T, N> {
         Some(item)
     }
 }
+
+impl<T: Exhaust, const N: usize> iter::FusedIterator for ExhaustArray<T, N> {}

--- a/src/impls/core_result.rs
+++ b/src/impls/core_result.rs
@@ -1,43 +1,28 @@
-use core::{fmt, iter};
-
 use crate::Exhaust;
 
 impl<T: Exhaust, E: Exhaust> Exhaust for Result<T, E> {
-    type Iter = ExhaustResult<T, E>;
+    type Iter = <remote::Result<T, E> as Exhaust>::Iter;
+    type Factory = <remote::Result<T, E> as Exhaust>::Factory;
 
-    fn exhaust() -> Self::Iter {
-        ExhaustResult(T::exhaust().map(Ok as _).chain(E::exhaust().map(Err as _)))
+    fn exhaust_factories() -> Self::Iter {
+        remote::Result::exhaust_factories()
+    }
+
+    fn from_factory(factory: Self::Factory) -> Self {
+        match remote::Result::from_factory(factory) {
+            remote::Result::Ok(v) => Ok(v),
+            remote::Result::Err(v) => Err(v),
+        }
     }
 }
 
-/// Iterator implementation for `Result::exhaust()`.
-#[derive(Clone)]
-#[allow(clippy::type_complexity)] // TODO: type_alias_impl_trait
-pub struct ExhaustResult<T, E>(
-    iter::Chain<
-        iter::Map<<T as Exhaust>::Iter, fn(T) -> Result<T, E>>,
-        iter::Map<<E as Exhaust>::Iter, fn(E) -> Result<T, E>>,
-    >,
-)
-where
-    T: Exhaust,
-    E: Exhaust;
-
-impl<T: Exhaust, E: Exhaust> Iterator for ExhaustResult<T, E> {
-    type Item = Result<T, E>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-
-#[allow(clippy::type_repetition_in_bounds)] // TODO: report false positive
-impl<T: Exhaust, E: Exhaust> fmt::Debug for ExhaustResult<T, E>
-where
-    T::Iter: fmt::Debug,
-    E::Iter: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ExhaustResult").field(&self.0).finish()
+/// Like the Serde “remote derive” pattern, we define a type imitating the real type
+/// which the derive macro can process.
+mod remote {
+    #[allow(missing_debug_implementations)] // not actually public
+    #[derive(crate::Exhaust)]
+    pub enum Result<T, E> {
+        Ok(T),
+        Err(E),
     }
 }

--- a/src/impls/core_sync.rs
+++ b/src/impls/core_sync.rs
@@ -1,0 +1,38 @@
+#![cfg_attr(not(target_has_atomic = "8"), allow(unused_imports, unused_macros))]
+
+macro_rules! impl_atomic {
+    ($t:ty, $atomic:ident) => {
+        impl Exhaust for atomic::$atomic {
+            type Iter = <$t as Exhaust>::Iter;
+            type Factory = <$t as Exhaust>::Factory;
+
+            fn exhaust_factories() -> Self::Iter {
+                <$t>::exhaust_factories()
+            }
+
+            fn from_factory(factory: Self::Factory) -> Self {
+                atomic::$atomic::new(factory)
+            }
+        }
+    };
+}
+use impl_atomic;
+
+#[rustfmt::skip]
+mod atomic_impl {
+    use core::sync::atomic;
+    use crate::Exhaust;
+    use super::impl_atomic;
+
+    #[cfg(target_has_atomic = "8")]  impl_atomic!(bool, AtomicBool);
+    #[cfg(target_has_atomic = "8")]  impl_atomic!(i8, AtomicI8);
+    #[cfg(target_has_atomic = "8")]  impl_atomic!(u8, AtomicU8);
+    #[cfg(target_has_atomic = "16")] impl_atomic!(i16, AtomicI16);
+    #[cfg(target_has_atomic = "16")] impl_atomic!(u16, AtomicU16);
+    #[cfg(target_has_atomic = "32")] impl_atomic!(i32, AtomicI32);
+    #[cfg(target_has_atomic = "32")] impl_atomic!(u32, AtomicU32);
+
+    // * No `AtomicUsize` on the principle that it might be too large.
+    // * No `AtomicPtr` on the principle that we don't produce nonsense pointers.
+    // * No `Ordering` because it is `#[non_exhaustive]`.
+}

--- a/src/impls/core_task.rs
+++ b/src/impls/core_task.rs
@@ -1,19 +1,19 @@
-use core::iter;
 use core::task;
 
 use crate::Exhaust;
 
 impl<T: Exhaust> Exhaust for task::Poll<T> {
-    type Iter = iter::Map<<Option<T> as Exhaust>::Iter, fn(Option<T>) -> task::Poll<T>>;
+    type Iter = <Option<T> as Exhaust>::Iter;
+    type Factory = <Option<T> as Exhaust>::Factory;
 
-    fn exhaust() -> Self::Iter {
-        Option::<T>::exhaust().map(option_to_poll as _)
+    fn exhaust_factories() -> Self::Iter {
+        Option::<T>::exhaust_factories()
     }
-}
 
-fn option_to_poll<T>(opt: Option<T>) -> task::Poll<T> {
-    match opt {
-        None => task::Poll::Pending,
-        Some(val) => task::Poll::Ready(val),
+    fn from_factory(factory: Self::Factory) -> Self {
+        match Option::<T>::from_factory(factory) {
+            None => task::Poll::Pending,
+            Some(val) => task::Poll::Ready(val),
+        }
     }
 }

--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -19,7 +19,7 @@ mod collections {
     impl<T, S> Exhaust for HashSet<T, S>
     where
         T: Exhaust + Eq + Hash,
-        S: Clone + Default + BuildHasher,
+        S: Default + BuildHasher,
     {
         type Iter = ExhaustSet<T>;
         type Factory = Vec<T::Factory>;
@@ -36,7 +36,7 @@ mod collections {
     where
         K: Exhaust + Eq + Hash,
         V: Exhaust,
-        S: Clone + Default + BuildHasher,
+        S: Default + BuildHasher,
     {
         type Iter = ExhaustMap<<HashSet<K, S> as Exhaust>::Iter, V>;
 

--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -60,7 +60,7 @@ mod io {
     use std::io;
 
     impl<T: Exhaust + AsRef<[u8]> + Clone> Exhaust for io::Cursor<T> {
-        type Iter = FlatZipMap<crate::Produce<T>, std::ops::RangeInclusive<u64>, io::Cursor<T>>;
+        type Iter = FlatZipMap<crate::Iter<T>, std::ops::RangeInclusive<u64>, io::Cursor<T>>;
         /// Returns each combination of a buffer state and a cursor position, except for those
         /// where the position is beyond the end of the buffer.
         fn exhaust_factories() -> Self::Iter {

--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -7,7 +7,7 @@ use std::sync;
 use std::vec::Vec;
 
 use crate::iteration::{peekable_exhaust, FlatZipMap};
-use crate::patterns::{factory_is_self, impl_newtype_generic};
+use crate::patterns::{factory_is_self, impl_newtype_generic, impl_singleton};
 use crate::Exhaust;
 
 use super::alloc_impls::{ExhaustMap, ExhaustSet, MapFactory};
@@ -106,13 +106,7 @@ impl Exhaust for std::io::Empty {
 //     }
 // }
 
-impl Exhaust for std::io::Sink {
-    type Iter = iter::Once<std::io::Sink>;
-    fn exhaust_factories() -> Self::Iter {
-        iter::once(std::io::sink())
-    }
-    factory_is_self!();
-}
+impl_singleton!([], std::io::Sink);
 
 impl_newtype_generic!(T: [], sync::Arc<T>, sync::Arc::new);
 impl_newtype_generic!(T: [], Pin<sync::Arc<T>>, sync::Arc::pin);

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -12,11 +12,11 @@ use crate::Exhaust;
 /// implementations.
 pub type Pei<T> = Peekable<<T as Exhaust>::Iter>;
 
-/// Construct a [`Peekable`] exhaustive iterator.
+/// Construct a [`Peekable`] exhaustive factory iterator.
 ///
 /// Peekable iterators are useful for iterating over the product of multiple iterators.
 pub fn peekable_exhaust<T: Exhaust>() -> Pei<T> {
-    T::exhaust().peekable()
+    T::exhaust_factories().peekable()
 }
 
 /// Perform “carry” within a pair of peekable iterators.

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -3,8 +3,8 @@
 //! These functions were found to be repeatedly useful within the built-in implementations,
 //! and are provided publicly in the expectation that they will have more uses.
 
-use core::fmt;
 use core::iter::Peekable;
+use core::{fmt, iter};
 
 use crate::Exhaust;
 
@@ -114,4 +114,12 @@ where
             }
         }
     }
+}
+
+impl<I, J, O> iter::FusedIterator for FlatZipMap<I, J, O>
+where
+    I: Iterator,
+    I::Item: Clone,
+    J: Iterator,
+{
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,6 @@ use core::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator};
 pub(crate) mod patterns;
 
 pub mod impls;
-/// Reexport for compatibility with v0.1.0;
-/// new code should use [`impls::ExhaustArray`].
-#[deprecated]
-pub use impls::ExhaustArray;
 
 mod convenience;
 pub use convenience::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,10 +181,6 @@ pub mod iteration;
 ///
 ///   * [`core::cell::UnsafeCell`]
 ///   * [`std::sync::Mutex`] and `RwLock`
-///   * [`core::sync::atomic::Atomic*`](core::sync::atomic)
-///
-///   A future version of the library might relax the [`Clone`] bound,
-///   but this is currently impossible.
 /// * Containers that permit duplicate items, and can therefore be unboundedly large:
 ///   * [`alloc::vec::Vec`]
 ///   * [`alloc::collections::VecDeque`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,10 +177,6 @@ pub mod iteration;
 /// * Pointers, for the same reason as references (and we could generate invalid pointers,
 ///   but that would be almost certainly pointless).
 /// * [`u64`], [`i64`], and [`f64`], because they are too large to feasibly exhaust.
-/// * Types which do not implement [`Clone`]:
-///
-///   * [`core::cell::UnsafeCell`]
-///   * [`std::sync::Mutex`] and `RwLock`
 /// * Containers that permit duplicate items, and can therefore be unboundedly large:
 ///   * [`alloc::vec::Vec`]
 ///   * [`alloc::collections::VecDeque`]
@@ -194,7 +190,6 @@ pub mod iteration;
 /// * [`core::ops::Range*`](core::ops), because it is ambiguous whether inverted (start > end)
 ///   ranges should be generated.
 /// * [`std::io::ErrorKind`] and other explicitly non-exhaustive types.
-/// * [`std::io::Stdout`] and other types whose sole use is in performing IO.
 pub trait Exhaust: Sized {
     /// Iterator type returned by [`Self::exhaust_factories()`].
     /// See the trait documentation for what properties this iterator should have.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ pub mod iteration;
 ///         }
 ///     }
 /// }
+/// impl std::iter::FusedIterator for ExhaustAsciiLetter {}
 ///
 /// assert_eq!(
 ///     AsciiLetter::exhaust().map(|l| l.0).collect::<String>(),
@@ -214,7 +215,7 @@ pub trait Exhaust: Sized {
     /// [`ExactSizeIterator`]); it should be treated as an implementation detail.
     ///
     /// </div>
-    type Iter: Iterator<Item = Self::Factory> + Clone;
+    type Iter: core::iter::FusedIterator<Item = Self::Factory> + Clone;
 
     /// Data which can be used to construct `Self`.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use core::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator};
 
 pub(crate) mod patterns;
 
-pub mod impls;
+mod impls;
 
 mod convenience;
 pub use convenience::*;

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -14,6 +14,37 @@ macro_rules! factory_is_self {
 }
 pub(crate) use factory_is_self;
 
+/// Implementation for types with exactly one value.
+macro_rules! impl_singleton {
+    // if Default is implemented
+    ([$($generics:tt)*], $self:ty) => {
+        impl<$($generics)*> $crate::Exhaust for $self {
+            type Iter = ::core::iter::Once<()>;
+            type Factory = ();
+            fn exhaust_factories() -> Self::Iter {
+                ::core::iter::once(())
+            }
+            fn from_factory((): Self::Factory) -> Self {
+                ::core::default::Default::default()
+            }
+        }
+    };
+    // if Default is not implemented
+    ([$($generics:tt)*], $self:ty, $ctor:expr) => {
+        impl<$($generics)*> $crate::Exhaust for $self {
+            type Iter = ::core::iter::Once<()>;
+            type Factory = ();
+            fn exhaust_factories() -> Self::Iter {
+                ::core::iter::once(())
+            }
+            fn from_factory((): Self::Factory) -> Self {
+                $ctor
+            }
+        }
+    };
+}
+pub(crate) use impl_singleton;
+
 macro_rules! impl_via_array {
     ($self:ty, $array:expr) => {
         impl $crate::Exhaust for $self {

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -80,7 +80,7 @@ macro_rules! impl_newtype_generic {
     ($tvar:ident : [ $( $bounds:tt )* ] , $container:ty, $wrap_fn:expr) => {
         impl<$tvar: $crate::Exhaust> $crate::Exhaust for $container
         where
-            $tvar: Clone + $( $bounds )*
+            $tvar: $( $bounds )*
         {
             type Iter = <$tvar as $crate::Exhaust>::Iter;
             fn exhaust_factories() -> Self::Iter {

--- a/tests/alloc_impls.rs
+++ b/tests/alloc_impls.rs
@@ -1,10 +1,42 @@
 extern crate alloc;
 use alloc::borrow::Cow;
 
-mod helper;
-use helper::check_double;
+use exhaust::Exhaust;
 
+mod helper;
+use helper::{check, check_double};
+
+/// Test for Cow<SomeTypeThatImplementsClone>
 #[test]
-fn impl_cow() {
+fn impl_cow_clone() {
     check_double::<Cow<'_, bool>>(vec![Cow::Owned(false), Cow::Owned(true)]);
+}
+
+/// Test for Cow with a type that does *not* implement Clone.
+/// We can't do this with the usual ones like [`str`] because they're all unbounded DSTs.
+/// (So, this implementation is unlikely to be very useful, really, but we might as well.)
+#[test]
+fn impl_cow_non_clone() {
+    #[derive(Debug, PartialEq, Exhaust)]
+    struct Foo(bool);
+
+    #[derive(Debug, PartialEq, Exhaust)]
+    struct FooOwned(Foo);
+
+    impl alloc::borrow::Borrow<Foo> for FooOwned {
+        fn borrow(&self) -> &Foo {
+            &self.0
+        }
+    }
+    impl alloc::borrow::ToOwned for Foo {
+        type Owned = FooOwned;
+        fn to_owned(&self) -> FooOwned {
+            FooOwned(Foo(self.0))
+        }
+    }
+
+    check::<Cow<'_, Foo>>(vec![
+        Cow::Owned(FooOwned(Foo(false))),
+        Cow::Owned(FooOwned(Foo(true))),
+    ]);
 }

--- a/tests/core_impls.rs
+++ b/tests/core_impls.rs
@@ -136,7 +136,7 @@ fn impl_array_of_3() {
 
 #[test]
 fn impl_option() {
-    check_double(vec![None, Some(false), Some(true)]);
+    check(vec![None, Some(false), Some(true)]);
 }
 
 #[test]

--- a/tests/deriving.rs
+++ b/tests/deriving.rs
@@ -35,7 +35,7 @@ where
     result
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 struct UnitStruct;
 
 #[test]
@@ -43,7 +43,7 @@ fn struct_unit() {
     std::assert_eq!(c::<UnitStruct>(), std::vec![UnitStruct]);
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 struct SimpleStruct {
     // At least three fields are needed to check the carry logic.
     a: bool,
@@ -100,7 +100,7 @@ fn struct_simple() {
     )
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 struct GenericStruct<T> {
     a: T,
     b: T,
@@ -121,7 +121,7 @@ fn struct_generic() {
     )
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 enum EmptyEnum {}
 
 #[test]
@@ -129,7 +129,7 @@ fn enum_empty() {
     std::assert_eq!(c::<EmptyEnum>(), std::vec![]);
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 enum OneValueEnum {
     Foo,
 }
@@ -139,7 +139,7 @@ fn enum_one_value() {
     std::assert_eq!(c::<OneValueEnum>(), std::vec![OneValueEnum::Foo]);
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 enum FieldlessEnum {
     Foo,
     Bar,
@@ -154,7 +154,7 @@ fn enum_fieldless_multi() {
     );
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 enum EnumWithFields {
     Foo(bool, bool),
     Bar(bool),
@@ -175,7 +175,7 @@ fn enum_fields() {
     );
 }
 
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Debug, exhaust::Exhaust, PartialEq)]
 enum EnumWithGeneric<T> {
     N,
     S(T),
@@ -194,13 +194,13 @@ fn enum_generic() {
 }
 
 mod module {
-    #[derive(Clone, ::exhaust::Exhaust)]
+    #[derive(::exhaust::Exhaust)]
     enum EnumInsideMod<T> {
         N,
         S(T),
     }
 
-    #[derive(Clone, Debug, PartialEq, ::exhaust::Exhaust)]
+    #[derive(Debug, PartialEq, ::exhaust::Exhaust)]
     struct StructInsideMod(bool);
 }
 
@@ -208,13 +208,13 @@ mod module {
 /// Exercise using the derive inside one.
 #[test]
 fn function_containing_derive() {
-    #[derive(Clone, exhaust::Exhaust)]
+    #[derive(exhaust::Exhaust)]
     enum EnumInsideFn<T> {
         N,
         S(T),
     }
 
-    #[derive(Clone, Debug, PartialEq, exhaust::Exhaust)]
+    #[derive(Debug, PartialEq, exhaust::Exhaust)]
     struct StructInsideFn(bool);
 
     std::assert_eq!(
@@ -224,7 +224,7 @@ fn function_containing_derive() {
 }
 
 #[allow(dead_code)]
-#[derive(Clone, exhaust::Exhaust)]
+#[derive(exhaust::Exhaust)]
 enum VariableNameHygieneTest {
     // These field and variant names shouldn't conflict with internal variables in the generated impl.
     Foo { has_next: (), item: (), f0: () },


### PR DESCRIPTION
Fixes:

* #6 
* #29 
* #19 (the iterators are now always unnameable)

Does part of:

* #2 
* #4

Conflicts with #20 a bit; the introduction of `Factory` distinct from `Self` means that overriding `Iterator::position()` would not work naively without specialization, but that is not essential.
