### PR TITLE
Remove use of workspace dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,13 @@ required-features = ["alloc"]
 
 [dependencies]
 exhaust-macros = { version = "0.1.1", path = "exhaust-macros" }
-# itertools is used for its powerset iterator, which is only available with alloc
-itertools = { workspace = true, optional = true }
-paste = "1.0.5"
-
-[workspace.dependencies]
+# itertools is used for its powerset iterator, which is only available with alloc,
+# but which we only use for exhausting set and map types.
+#
 # Note!!! It would be nice if we could use a wide range of itertools versions,
 # but there is a bug fixed in 0.13.0, <https://github.com/rust-itertools/itertools/issues/337>,
 # which affects `ExhaustHashMap` and `ExhaustBTreeMap`, so it actually matters that we have 0.13.0
 # here. But when 0.14.0 is released, consider changing this to `>=0.13.0, <0.15.0` so that we can
 # allow dependents to stay off the upgrade treadmill without duplicating versions.
-itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.13.0", optional = true, default-features = false, features = ["use_alloc"] }
+paste = "1.0.5"

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-itertools = { workspace = true }
+itertools = { version = "0.13.0", default-features = false }
 proc-macro2 = "1.0.86"
 quote = "1.0.37"
 syn = { version = "2.0.13", features = ["full"] }


### PR DESCRIPTION
They are incompatible with Rust 1.60, and while I don't want to stick too hard to that arbitrary MSRV, this was accidental and only worked in CI by accident because the lock file was already set by nightly:

> warning: /home/runner/work/exhaust/exhaust/exhaust-macros/Cargo.toml: dependency (itertools) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions