### PR TITLE
Bump version number of `exhaust-macros`.

### DIFF
--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exhaust-macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Proc-macro support for the 'exhaust' library."
 repository = "https://github.com/kpreid/exhaust/"


### PR DESCRIPTION
Whoops, should have done that in the last PR. Thought it'd already been done.