### PR TITLE
Add `Debug` bounds to iterator and factory; expand macro docs.

### DIFF
--- a/exhaust-macros/src/lib.rs
+++ b/exhaust-macros/src/lib.rs
@@ -183,7 +183,7 @@ fn tuple_impl(size: u64) -> Result<TokenStream2, syn::Error> {
         &ConstructorSyntax::Tuple,
     );
 
-    let iterator_impls = ctx.impl_iterator_traits(
+    let iterator_impls = ctx.impl_iterator_and_factory_traits(
         quote! {
             match self {
                 Self { #field_pats } => {
@@ -289,7 +289,7 @@ fn exhaust_iter_struct(
     // Note: The iterator must have trait bounds because its fields, being of type
     // `<SomeOtherTy as Exhaust>::Iter`, require that `SomeOtherTy: Exhaust`.
 
-    let impls = ctx.impl_iterator_traits(
+    let impls = ctx.impl_iterator_and_factory_traits(
         quote! {
             match self {
                 Self { #field_pats } => {
@@ -565,7 +565,7 @@ fn exhaust_iter_enum(
     let (impl_generics, ty_generics, augmented_where_predicates) =
         ctx.generics_with_bounds(syn::parse_quote! {});
 
-    let impls = ctx.impl_iterator_traits(
+    let impls = ctx.impl_iterator_and_factory_traits(
         quote! {
             match &mut self.0 {
                 #( #variant_next_arms , )*

--- a/src/impls/alloc_impls.rs
+++ b/src/impls/alloc_impls.rs
@@ -175,7 +175,7 @@ where
 impl<KI, V> fmt::Debug for ExhaustMap<KI, V>
 where
     KI: fmt::Debug + Iterator<Item: fmt::Debug>,
-    V: fmt::Debug + Exhaust<Iter: fmt::Debug, Factory: fmt::Debug>,
+    V: Exhaust<Iter: fmt::Debug, Factory: fmt::Debug>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExhaustMap")

--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::wildcard_imports)]
 
-use core::iter;
 use core::pin::Pin;
+use core::{fmt, iter};
 
 use crate::iteration::{peekable_exhaust, FlatZipMap};
 use crate::patterns::{factory_is_self, impl_newtype_generic, impl_singleton};
@@ -59,7 +59,7 @@ mod io {
     use super::*;
     use std::io;
 
-    impl<T: Exhaust + AsRef<[u8]> + Clone> Exhaust for io::Cursor<T> {
+    impl<T: Exhaust + AsRef<[u8]> + Clone + fmt::Debug> Exhaust for io::Cursor<T> {
         type Iter = FlatZipMap<crate::Iter<T>, std::ops::RangeInclusive<u64>, io::Cursor<T>>;
         /// Returns each combination of a buffer state and a cursor position, except for those
         /// where the position is beyond the end of the buffer.

--- a/tests/deriving.rs
+++ b/tests/deriving.rs
@@ -232,6 +232,25 @@ enum VariableNameHygieneTest {
     Done,
 }
 
+#[test]
+fn debug_impls() {
+    use exhaust::Exhaust;
+    use std::{assert_eq, format, iter::Iterator};
+
+    #[derive(Debug, PartialEq, Exhaust)]
+    enum Foo {
+        X,
+        Y,
+    }
+
+    // TODO: It would be better to print some state, but that requires more code generation work.
+    let mut iter = Foo::exhaust_factories();
+    assert_eq!(format!("{iter:?}"), "ExhaustFooIter { .. }");
+    let factory = Iterator::next(&mut iter).unwrap();
+    assert_eq!(format!("{factory:?}"), "ExhaustFooFactory { .. }");
+    assert_eq!(Foo::from_factory(factory), Foo::X);
+}
+
 /// The presence of this trait's methods should not disrupt the generated code
 #[allow(dead_code)]
 trait ConfusingTraitInScope {


### PR DESCRIPTION
This is a significant choice. I believe it is better to require them than not to, because this allows the derived iterator and factory to implement `Debug` to actually print details, whereas if we did not, we would have to either wait for RFC 2056 `trivial_bounds` or require the user of the macro to explicitly specify “also generate Debug”.

These bounds do not affect what types can implement `Exhaust`, other than if `type Factory = Self;` is used and `Self` does not implement `Debug`, a wrapper may be needed.

The derive macro now implements `Debug` for the factory.