### PR TITLE
make generated type names camel case

### DIFF
--- a/exhaust-macros/src/lib.rs
+++ b/exhaust-macros/src/lib.rs
@@ -246,7 +246,7 @@ fn exhaust_iter_struct(
 
     let factory_state_struct_type = Ident::new(
         &format!(
-            "__ExhaustFactoryState_{}",
+            "ExhaustFactoryState{}",
             ctx.item_type.name_for_incorporation()?
         ),
         Span::mixed_site(),
@@ -387,14 +387,14 @@ fn exhaust_iter_enum(
     // so that the user of the macro cannot depend on its implementation details.
     let iter_state_enum_type = Ident::new(
         &format!(
-            "__ExhaustIterState_{}",
+            "ExhaustIterState{}",
             ctx.item_type.name_for_incorporation()?
         ),
         Span::mixed_site(),
     );
     let factory_state_enum_type = Ident::new(
         &format!(
-            "__ExhaustFactoryState_{}",
+            "ExhaustFactoryState{}",
             ctx.item_type.name_for_incorporation()?
         ),
         Span::mixed_site(),


### PR DESCRIPTION
Fixes #44.

Since the types are private as of 0.2.0, I don't think this is a breaking change, nor do I think it could conflict with any caller-defined types.