### PR TITLE
Deps: Allow itertools version 0.14.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,11 @@ mutants = "0.0.3"
 paste = "1.0.5"
 
 [workspace.dependencies]
-# Note!!! It would be nice if we could use a wide range of itertools versions,
-# but there is a bug fixed in 0.13.0, <https://github.com/rust-itertools/itertools/issues/337>,
-# which affects `ExhaustHashMap` and `ExhaustBTreeMap`, so it actually matters that we have 0.13.0
-# here. But when 0.14.0 is released, consider changing this to `>=0.13.0, <0.15.0` so that we can
-# allow dependents to stay off the upgrade treadmill without duplicating versions.
-itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
+# Minimum version of `itertools` is 0.13.0 because we need this bug fixed,
+#   <https://github.com/rust-itertools/itertools/issues/337>,
+# which affects `ExhaustMap`. 0.14 is the current latest version, which contains no breaking
+# changes relevant to our usages: according to the changelog,
+#   * Increased MSRV to 1.63.0
+#   * Removed generic parameter from cons_tuples
+# neither of which affects us.
+itertools = { version = ">=0.13.0, <0.15", default-features = false, features = ["use_alloc"] }

--- a/exhaust-macros/src/lib.rs
+++ b/exhaust-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use itertools::{izip, Itertools as _};
+use itertools::izip;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens as _};
@@ -413,7 +413,7 @@ fn exhaust_iter_enum(
         Vec<TokenStream2>,
         Vec<TokenStream2>,
         Vec<TokenStream2>,
-    ) = e
+    ) = itertools::multiunzip(e
         .variants
         .iter()
         .zip(state_enum_progress_variants.iter())
@@ -480,8 +480,7 @@ fn exhaust_iter_enum(
             quote! {},
             quote! { compile_error!("done advancer not used") },
             quote! { compile_error!("done factory variant not used") },
-        )))
-        .multiunzip();
+        ))));
 
     factory_variant_decls.pop(); // no Done arm in the factory enum
 


### PR DESCRIPTION
Also reduced uses of `itertools::Itertools`, so we can keep a closer eye on which parts of `itertools` we are using.