### PR TITLE
Add `Indexable` trait.

### DIFF
--- a/src/impls/alloc_impls.rs
+++ b/src/impls/alloc_impls.rs
@@ -1,4 +1,5 @@
 use core::iter::FusedIterator;
+use core::ops::Deref;
 use core::pin::Pin;
 use core::{fmt, iter};
 
@@ -11,13 +12,13 @@ use alloc::vec::Vec;
 use itertools::Itertools as _;
 
 use crate::iteration::peekable_exhaust;
-use crate::patterns::{delegate_factory_and_iter, impl_newtype_generic};
+use crate::patterns::{delegate_factory_and_iter, impl_newtype_generic_indexable};
 use crate::Exhaust;
 
-impl_newtype_generic!(T: [], Box<T>, Box::new);
-impl_newtype_generic!(T: [], Rc<T>, Rc::new);
-impl_newtype_generic!(T: [], Pin<Box<T>>, Box::pin);
-impl_newtype_generic!(T: [], Pin<Rc<T>>, Rc::pin);
+impl_newtype_generic_indexable!(T: [], Box<T>, Box::new, Deref::deref);
+impl_newtype_generic_indexable!(T: [], Rc<T>, Rc::new, Deref::deref);
+impl_newtype_generic_indexable!(T: [], Pin<Box<T>>, Box::pin, Deref::deref);
+impl_newtype_generic_indexable!(T: [], Pin<Rc<T>>, Rc::pin, Deref::deref);
 
 /// Note that this implementation necessarily ignores the borrowed versus owned distinction;
 /// every value returned will be a [`Cow::Owned`], not a [`Cow::Borrowed`].

--- a/src/impls/array.rs
+++ b/src/impls/array.rs
@@ -1,7 +1,7 @@
 use core::{fmt, iter};
 
 use crate::iteration::{carry, peekable_exhaust};
-use crate::Exhaust;
+use crate::{Exhaust, Indexable};
 
 impl<T: Exhaust, const N: usize> Exhaust for [T; N] {
     type Iter = ExhaustArray<T, N>;
@@ -14,6 +14,35 @@ impl<T: Exhaust, const N: usize> Exhaust for [T; N] {
     }
     fn from_factory(factory: Self::Factory) -> Self {
         factory.map(T::from_factory)
+    }
+}
+
+impl<T: Indexable, const N: usize> Indexable for [T; N] {
+    const VALUE_COUNT: usize = array_value_count(T::VALUE_COUNT, N);
+
+    fn to_index(array: &Self) -> usize {
+        let mut value_index = 0;
+        // Same algorithm as assembling digits into a number.
+        for element in array {
+            value_index *= T::VALUE_COUNT;
+            value_index += T::to_index(element);
+        }
+        value_index
+    }
+
+    fn from_index(mut index: usize) -> Self {
+        // Note: We could skip `indices` and build the final array in-place, but there
+        // is no reverse counterpart to `core::array::from_fn()`, so we'd need one of
+        // *  unsafe and `MaybeUninit` to fill the array backwards,
+        // * exponentiation to obtain the “digits” in forward order, or
+        // * reversing the array of `T` afterward.
+        // For now, this is boring and correct and has O(N) space overhead, not O(N*size_of(T)).
+        let mut indices: [usize; N] = [0; N];
+        for element_index in indices.iter_mut().rev() {
+            *element_index = index.rem_euclid(T::VALUE_COUNT);
+            index = index.div_euclid(T::VALUE_COUNT);
+        }
+        indices.map(T::from_index)
     }
 }
 
@@ -103,3 +132,20 @@ impl<T: Exhaust, const N: usize> Iterator for ExhaustArray<T, N> {
 }
 
 impl<T: Exhaust, const N: usize> iter::FusedIterator for ExhaustArray<T, N> {}
+
+#[mutants::skip] // difficult to test the edge cases exactly unless we expose this fn
+const fn array_value_count(inner_value_count: usize, length: usize) -> usize {
+    #[allow(clippy::cast_possible_truncation)]
+    let n = if length as u128 > u32::MAX as u128 {
+        panic!("array length too large for Indexable");
+    } else {
+        length as u32
+    };
+
+    match inner_value_count.checked_pow(n) {
+        Some(count) => count,
+        // Ideally, we would print the value, but formatting in const expressions is not
+        // yet allowed.
+        None => panic!("total value count too large for Indexable"),
+    }
+}

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -13,6 +13,18 @@ impl crate::Exhaust for bool {
     crate::patterns::factory_is_self!();
 }
 
+impl crate::Indexable for bool {
+    const VALUE_COUNT: usize = 2;
+
+    fn to_index(value: &Self) -> usize {
+        usize::from(*value)
+    }
+
+    fn from_index(index: usize) -> Self {
+        [false, true][index]
+    }
+}
+
 #[derive(Clone, Debug)]
 pub /*-in-private*/ struct ExhaustBool(State);
 

--- a/src/impls/core_cell.rs
+++ b/src/impls/core_cell.rs
@@ -1,11 +1,23 @@
 use core::cell;
 
 use crate::patterns::{delegate_factory_and_iter, impl_newtype_generic};
-use crate::Exhaust;
+use crate::{Exhaust, Indexable};
 
 impl_newtype_generic!(T: [], cell::Cell<T>, cell::Cell::new);
 impl_newtype_generic!(T: [], cell::RefCell<T>, cell::RefCell::new);
 impl_newtype_generic!(T: [], cell::UnsafeCell<T>, cell::UnsafeCell::new);
+
+impl<T: Copy + Indexable> Indexable for cell::Cell<T> {
+    const VALUE_COUNT: usize = T::VALUE_COUNT;
+
+    fn to_index(value: &Self) -> usize {
+        T::to_index(&value.get())
+    }
+
+    fn from_index(index: usize) -> Self {
+        cell::Cell::new(T::from_index(index))
+    }
+}
 
 impl<T: Exhaust> Exhaust for cell::OnceCell<T> {
     delegate_factory_and_iter!(Option<T>);

--- a/src/impls/core_cmp.rs
+++ b/src/impls/core_cmp.rs
@@ -1,8 +1,11 @@
 use core::cmp::Ordering;
 
-use crate::patterns::{impl_newtype_generic, impl_via_array};
+use crate::patterns::{impl_newtype_generic_indexable, impl_via_array};
 
-impl_newtype_generic!(T: [], core::cmp::Reverse<T>, core::cmp::Reverse);
+impl_newtype_generic_indexable!(T: [], core::cmp::Reverse<T>, core::cmp::Reverse, rev_get);
+fn rev_get<T>(rev: &core::cmp::Reverse<T>) -> &T {
+    &rev.0
+}
 
 impl_via_array!(
     Ordering,

--- a/src/impls/core_convert.rs
+++ b/src/impls/core_convert.rs
@@ -1,6 +1,6 @@
 use core::iter;
 
-use crate::Exhaust;
+use crate::{Exhaust, Indexable};
 
 impl Exhaust for core::convert::Infallible {
     type Iter = iter::Empty<core::convert::Infallible>;
@@ -8,4 +8,19 @@ impl Exhaust for core::convert::Infallible {
         iter::empty()
     }
     crate::patterns::factory_is_self!();
+}
+
+impl Indexable for core::convert::Infallible {
+    const VALUE_COUNT: usize = 0;
+
+    #[mutants::skip]
+    fn to_index(value: &Self) -> usize {
+        match *value {}
+    }
+
+    #[track_caller]
+    #[mutants::skip]
+    fn from_index(_: usize) -> Self {
+        panic!("core::convert::Infallible has no valid indices")
+    }
 }

--- a/src/impls/core_num.rs
+++ b/src/impls/core_num.rs
@@ -3,7 +3,7 @@ use core::num::{self, NonZero};
 use core::ops::RangeInclusive;
 
 use crate::patterns::{
-    factory_is_self, impl_iterator_for_newtype, impl_newtype_generic, impl_via_array,
+    factory_is_self, impl_iterator_for_newtype, impl_newtype_generic_indexable, impl_via_array,
 };
 use crate::Exhaust;
 
@@ -127,4 +127,7 @@ impl_via_array!(
     ]
 );
 
-impl_newtype_generic!(T: [], num::Wrapping<T>, num::Wrapping);
+impl_newtype_generic_indexable!(T: [], num::Wrapping<T>, num::Wrapping, wrap_get);
+fn wrap_get<T>(value: &core::num::Wrapping<T>) -> &T {
+    &value.0
+}

--- a/src/impls/primitive.rs
+++ b/src/impls/primitive.rs
@@ -1,12 +1,15 @@
 use crate::patterns::{
-    delegate_factory_and_iter, impl_newtype_generic, impl_singleton, impl_via_range,
+    delegate_factory_and_iter, impl_newtype_generic_indexable, impl_singleton, impl_via_range,
 };
 use crate::Exhaust;
 
 impl_singleton!([], ());
 
 // Implement single-element tuples in the same way we implement other generic containers.
-impl_newtype_generic!(T: [], (T,), |x| (x,));
+impl_newtype_generic_indexable!(T: [], (T,), |x| (x,), tuple_1_get);
+fn tuple_1_get<T>(value: &(T,)) -> &T {
+    &value.0
+}
 
 // Generates tuple implementations from 2 to 12 items.
 // 12 was chosen as the same size the standard library offers.

--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -1,12 +1,13 @@
 #![allow(clippy::wildcard_imports)]
 
+use core::ops::Deref;
 use core::pin::Pin;
 use core::{fmt, iter};
 
 use crate::iteration::{peekable_exhaust, FlatZipMap};
 use crate::patterns::{
-    delegate_factory_and_iter, factory_is_self, impl_newtype_generic, impl_singleton,
-    impl_via_array,
+    delegate_factory_and_iter, factory_is_self, impl_newtype_generic,
+    impl_newtype_generic_indexable, impl_singleton, impl_via_array,
 };
 use crate::Exhaust;
 
@@ -140,8 +141,8 @@ mod sync {
     use super::*;
     use std::sync;
 
-    impl_newtype_generic!(T: [], sync::Arc<T>, sync::Arc::new);
-    impl_newtype_generic!(T: [], Pin<sync::Arc<T>>, sync::Arc::pin);
+    impl_newtype_generic_indexable!(T: [], sync::Arc<T>, sync::Arc::new, Deref::deref);
+    impl_newtype_generic_indexable!(T: [], Pin<sync::Arc<T>>, sync::Arc::pin, Deref::deref);
 
     impl_newtype_generic!(T: [], sync::Mutex<T>, sync::Mutex::new);
     impl_newtype_generic!(T: [], sync::RwLock<T>, sync::RwLock::new);

--- a/src/indexable.rs
+++ b/src/indexable.rs
@@ -1,0 +1,36 @@
+use crate::Exhaust;
+
+/// Types whose values can be converted to and from consecutive integers.
+///
+/// If the total number of values of the type exceeds [`usize::MAX`], then compilation will fail
+/// even if the trait implementation exists.
+/// (Note that this is a more lenient rule than [`ExactSizeIterator`]’s; therefore, some generic
+/// types may be able to implement [`Indexable`] but not
+/// [`Exhaust<Iter: ExactSizeIterator>`][Exhaust].)
+///
+/// # Example
+///
+/// The indexing of an array of booleans works out to be identical to that of a binary number:
+///
+/// ```
+/// use exhaust::Indexable;
+///
+/// assert_eq!(<[bool; 4]>::to_index(&[true, false, true, true]), 0b1011);
+/// assert_eq!(<[bool; 4]>::from_index(0b0101), [false, true, false, true]);
+/// ```
+pub trait Indexable: Exhaust {
+    /// Number of distinct values of this type.
+    /// Equivalent to `Self::exhaust().len()`, but is a constant.
+    const VALUE_COUNT: usize;
+
+    /// Returns the position within `Self::exhaust()` that `value` may be found.
+    ///
+    /// Equivalent to `Self::exhaust().position(value).unwrap()`, but more efficient;
+    /// note that a correct implementation cannot panic.
+    fn to_index(value: &Self) -> usize;
+
+    /// Equivalent to `Self::exhaust().nth(index).unwrap()`.
+    ///
+    /// Panics if `index >= Self::VALUE_COUNT`.
+    fn from_index(index: usize) -> Self;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,9 @@ pub(crate) mod patterns;
 
 mod impls;
 
+mod indexable;
+pub use indexable::Indexable;
+
 pub mod iteration;
 
 #[doc(hidden)] // for use by derive macro only

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -31,20 +31,11 @@ pub(crate) use delegate_factory_and_iter;
 
 /// Implementation for types with exactly one value.
 macro_rules! impl_singleton {
-    // if Default is implemented
+    // For use if Default is implemented
     ([$($generics:tt)*], $self:ty) => {
-        impl<$($generics)*> $crate::Exhaust for $self {
-            type Iter = ::core::iter::Once<()>;
-            type Factory = ();
-            fn exhaust_factories() -> Self::Iter {
-                ::core::iter::once(())
-            }
-            fn from_factory((): Self::Factory) -> Self {
-                ::core::default::Default::default()
-            }
-        }
+        $crate::patterns::impl_singleton!([$($generics)*], $self, ::core::default::Default::default());
     };
-    // if Default is not implemented
+    // For use if Default is not implemented
     ([$($generics:tt)*], $self:ty, $ctor:expr) => {
         impl<$($generics)*> $crate::Exhaust for $self {
             type Iter = ::core::iter::Once<()>;
@@ -53,6 +44,20 @@ macro_rules! impl_singleton {
                 ::core::iter::once(())
             }
             fn from_factory((): Self::Factory) -> Self {
+                $ctor
+            }
+        }
+
+        impl<$($generics)*> $crate::Indexable for $self {
+            const VALUE_COUNT: usize = 1;
+
+            fn to_index(value: &Self) -> usize {
+                let _ = value;
+                0
+            }
+
+            fn from_index(index: usize) -> Self {
+                assert!(index == 0);
                 $ctor
             }
         }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -63,7 +63,7 @@ pub(crate) use impl_singleton;
 /// Implement `Exhaust` for `$self` by iterating over the given array.
 /// The array must have no more than `u8::MAX - 1` (254) elements.
 macro_rules! impl_via_array {
-    ($self:ty, $array:expr) => {
+    ($self:ty, [$($item:path),* $(,)?]) => {
         // block to hide the non-uniquely named items
         const _: () = {
             impl $crate::Exhaust for $self {
@@ -80,7 +80,19 @@ macro_rules! impl_via_array {
                 $crate::patterns::factory_is_self!();
             }
 
-            const VALUES: &[$self; $array.len()] = &$array;
+            impl $crate::Indexable for $self {
+                const VALUE_COUNT: usize = VALUES.len();
+
+                fn to_index(value: &Self) -> usize {
+                    $crate::patterns::match_to_index!(value ; $($item),*)
+                }
+
+                fn from_index(index: usize) -> Self {
+                    VALUES[index]
+                }
+            }
+
+            const VALUES: &[$self; [$($item),*].len()] = &[$($item),*];
 
             // Opaque iterator struct for this particular `Exhaust` implementation.
             // Public-in-private type as a substitute for associated type `impl Iterator`.
@@ -129,12 +141,47 @@ macro_rules! impl_via_array {
 }
 pub(crate) use impl_via_array;
 
+// Helper for impl_via_array
+macro_rules! match_to_index {
+    ($var:ident ; $p0:path, $p1:path) => {
+        match $var {
+            $p0 => 0,
+            $p1 => 1,
+        }
+    };
+    ($var:ident ; $p0:path, $p1:path, $p2:path) => {
+        match $var {
+            $p0 => 0,
+            $p1 => 1,
+            $p2 => 2,
+        }
+    };
+    ($var:ident ; $p0:path, $p1:path, $p2:path, $p3:path) => {
+        match $var {
+            $p0 => 0,
+            $p1 => 1,
+            $p2 => 2,
+            $p3 => 3,
+        }
+    };
+    ($var:ident ; $p0:path, $p1:path, $p2:path, $p3:path, $p4:path) => {
+        match $var {
+            $p0 => 0,
+            $p1 => 1,
+            $p2 => 2,
+            $p3 => 3,
+            $p4 => 4,
+        }
+    };
+}
+pub(crate) use match_to_index;
+
 macro_rules! impl_via_range {
     ($self:ty, $start:expr, $end:expr) => {
         impl $crate::Exhaust for $self {
             type Iter = ::core::ops::RangeInclusive<$self>;
             fn exhaust_factories() -> Self::Iter {
-                (($start)..=($end))
+                $start..=$end
             }
             $crate::patterns::factory_is_self!();
         }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -214,6 +214,28 @@ macro_rules! impl_newtype_generic {
 }
 pub(crate) use impl_newtype_generic;
 
+macro_rules! impl_newtype_generic_indexable {
+    ($tvar:ident : [ $( $bounds:tt )* ] , $container:ty, $wrap_fn:expr, $unwrap_ref_fn:expr) => {
+        $crate::patterns::impl_newtype_generic!($tvar : [ $( $bounds )* ] , $container, $wrap_fn);
+
+        impl<$tvar: $crate::Indexable> $crate::Indexable for $container
+        where
+            $tvar: $( $bounds )*
+        {
+            const VALUE_COUNT: usize = <$tvar as $crate::Indexable>::VALUE_COUNT;
+
+            fn to_index(value: &Self) -> usize {
+                <$tvar as $crate::Indexable>::to_index($unwrap_ref_fn(value))
+            }
+
+            fn from_index(index: usize) -> Self {
+                $wrap_fn(<$tvar as $crate::Indexable>::from_index(index))
+            }
+        }
+    };
+}
+pub(crate) use impl_newtype_generic_indexable;
+
 /// Implement [`Iterator`] and [`DoubleEndedIterator`] for a newtype
 /// to forward to its `.0` field and call a function to map each item.
 ///

--- a/src/test_compile_fail.rs
+++ b/src/test_compile_fail.rs
@@ -34,6 +34,11 @@ pub struct OptionFactoryNotAccessible;
 /// ```
 pub struct ConflictWithGeneratedTypeNames;
 
+/// ```compile_fail
+/// const TOO_MANY_VALS: usize = <[u8; 8] as exhaust::Indexable>::VALUE_COUNT;
+/// ```
+pub struct IndexableArrayTooLarge;
+
 /// Tests of the parsing of the `#[exhaust]` attribute.
 mod attr {
     /// ```compile_fail

--- a/tests/core_impls_and_misc/core_impls.rs
+++ b/tests/core_impls_and_misc/core_impls.rs
@@ -62,6 +62,18 @@ fn impl_bool() {
 }
 
 #[test]
+fn impl_i8() {
+    check_double((i8::MIN..=i8::MAX).collect());
+    check_indexable::<i8>();
+}
+
+#[test]
+fn impl_u8() {
+    check_double((u8::MIN..=u8::MAX).collect());
+    check_indexable::<u8>();
+}
+
+#[test]
 fn impl_f32() {
     // We can't exhaustively test it but we can check some easy properties.
     assert_eq!(f32::exhaust().next(), Some(0.0));

--- a/tests/core_impls_and_misc/core_impls.rs
+++ b/tests/core_impls_and_misc/core_impls.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use core::num;
 use core::ops;
 
-use exhaust::Exhaust;
+use exhaust::{Exhaust, Indexable};
 
 use crate::helper::{check, check_double, check_double_exact};
 
@@ -135,6 +135,15 @@ fn impl_array_of_2() {
         [true, false],
         [true, true],
     ]);
+}
+
+#[test]
+fn array_indexable_near_usize_max() {
+    const N: usize = size_of::<usize>() - 1;
+    assert_eq!(
+        <[u8; N]>::VALUE_COUNT,
+        256usize.pow(u32::try_from(N).unwrap())
+    );
 }
 
 #[test]

--- a/tests/core_impls_and_misc/core_impls.rs
+++ b/tests/core_impls_and_misc/core_impls.rs
@@ -6,11 +6,12 @@ use core::ops;
 
 use exhaust::{Exhaust, Indexable};
 
-use crate::helper::{check, check_double, check_double_exact};
+use crate::helper::{check, check_double, check_double_exact, check_indexable};
 
 #[test]
 fn impl_unit() {
     check_double_exact(vec![()]);
+    check_indexable::<()>();
     assert_eq!(size_of_val(&<()>::exhaust()), 1);
 }
 
@@ -40,6 +41,7 @@ fn impl_nontrivial_tuple() {
 fn impl_phantom_data() {
     use core::marker::PhantomData;
     check_double_exact::<PhantomData<bool>>(vec![PhantomData]);
+    check_indexable::<PhantomData<bool>>();
     assert_eq!(size_of_val(&<PhantomData<bool>>::exhaust()), 1);
 }
 
@@ -48,12 +50,14 @@ fn impl_phantom_data() {
 #[test]
 fn impl_infallible() {
     check_double_exact(Vec::<core::convert::Infallible>::new());
+    check_indexable::<core::convert::Infallible>();
     assert_eq!(size_of_val(&core::convert::Infallible::exhaust()), 0);
 }
 
 #[test]
 fn impl_bool() {
     check_double_exact(vec![false, true]);
+    check_indexable::<bool>();
     assert_eq!(size_of_val(&<bool>::exhaust()), 1);
 }
 
@@ -110,21 +114,25 @@ fn impl_nonzero_signed() {
 #[test]
 fn impl_array_of_unit_type() {
     check(vec![[(), (), (), ()]]);
+    check_indexable::<[(); 4]>();
 }
 
 #[test]
 fn impl_array_of_uninhabited_type() {
     check(Vec::<[core::convert::Infallible; 4]>::new());
+    check_indexable::<[core::convert::Infallible; 4]>();
 }
 
 #[test]
 fn impl_array_of_0() {
     check::<[bool; 0]>(vec![[]]);
+    check_indexable::<[bool; 0]>();
 }
 
 #[test]
 fn impl_array_of_1() {
     check::<[bool; 1]>(vec![[false], [true]]);
+    check_indexable::<[bool; 1]>();
 }
 
 #[test]
@@ -135,6 +143,7 @@ fn impl_array_of_2() {
         [true, false],
         [true, true],
     ]);
+    check_indexable::<[bool; 2]>();
 }
 
 #[test]
@@ -158,6 +167,7 @@ fn impl_array_of_3() {
         [true, true, false],
         [true, true, true],
     ]);
+    check_indexable::<[bool; 3]>();
 }
 
 #[test]
@@ -192,6 +202,7 @@ mod impl_cell {
     #[test]
     fn impl_cell() {
         check_double_exact(vec![Cell::new(false), Cell::new(true)]);
+        check_indexable::<Cell<bool>>();
     }
 
     #[test]
@@ -252,6 +263,7 @@ mod impl_fmt {
     #[test]
     fn impl_error() {
         check_double(vec![fmt::Error]);
+        check_indexable::<fmt::Error>();
     }
 }
 

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -3,7 +3,7 @@ use ::std::fmt;
 use ::std::prelude::rust_2021::*;
 use ::std::vec::Vec;
 
-use ::exhaust::Exhaust;
+use ::exhaust::{Exhaust, Indexable};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -102,4 +102,27 @@ where
         expected_len,
         "len() does not match number of elements produced"
     );
+}
+
+/// Check that the [`Indexable`] implementation agrees with the [`Exhaust`] implementation.
+///
+/// This does not check any properties of the [`Exhaust`] implementation;
+/// use it only together with [`check()`] or such.
+#[allow(dead_code)] // compiled from multiple crates
+#[track_caller]
+pub(crate) fn check_indexable<T: Indexable + fmt::Debug + PartialEq>() {
+    for (index_from_iter, value_from_iter) in T::exhaust().enumerate() {
+        let index_from_trait = T::to_index(&value_from_iter);
+        assert!(
+            index_from_iter == index_from_trait,
+            "T::to_index({value_from_iter:?}) returned {index_from_trait}, \
+            but its position in iteration is {index_from_iter}"
+        );
+        let value_from_trait = T::from_index(index_from_iter);
+        assert!(
+            value_from_iter == value_from_trait,
+            "T::from_index({index_from_iter}) returned {value_from_trait:?}, \
+            but the value from iteration is {value_from_iter:?}"
+        );
+    }
 }


### PR DESCRIPTION
Prototype implementation of #20. Lacks `derive(Indexable)`.