### PR TITLE
Update version number and changelog to 0.2.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.2.2 (2025-03-08)
+
+### Added
+
+* `impl Exhaust for ...`
+  * `core::fmt::Alignment`
+  * `core::fmt::Error`
+  * `core::cell::OnceCell`
+  * `core::ops::Bound`
+  * `core::ops::ControlFlow`
+  * `core::ops::RangeFrom`
+  * `core::ops::RangeFull`
+  * `core::ops::RangeTo`
+  * `core::ops::RangeToInclusive`
+  * `std::sync::OnceLock`
+  * `std::sync::mpsc::RecvError`
+  * `std::sync::mpsc::RecvTimeoutError`
+  * `std::sync::mpsc::SendError`
+  * `std::sync::mpsc::TryRecvError`
+  * `std::sync::mpsc::TrySendError`
+
+* The dependency on `itertools` can now use either version 0.14 or version 0.13.
+  This has no effect on the functionality of `exhaust`.
+
 ## 0.2.1 (2024-09-26)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "exhaust"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.80.0"
 description = "Trait and derive macro for working with all possible values of a type (exhaustive enumeration)."

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exhaust-macros"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Proc-macro support for the 'exhaust' library."
 repository = "https://github.com/kpreid/exhaust/"


### PR DESCRIPTION
Note that while there are no direct changes in `exhaust-macros`, it gets the `itertools` version relaxation from the workspace. This is all backwards compatible, so we don't need to change the `exhaust` → `exhaust-macros` dependency requirement.