### PR TITLE
Remove use of `paste` library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ exhaust-macros = { version = "0.2.1", path = "exhaust-macros" }
 # itertools is used for its powerset iterator, which is only available with alloc
 itertools = { workspace = true, optional = true }
 mutants = "0.0.3"
-paste = "1.0.5"
 
 [workspace.dependencies]
 # Minimum version of `itertools` is 0.13.0 because we need this bug fixed,

--- a/src/impls/core_num.rs
+++ b/src/impls/core_num.rs
@@ -1,47 +1,60 @@
 use core::iter;
-use core::num;
-
-use paste::paste;
+use core::num::{self, NonZero};
 
 use crate::patterns::{impl_newtype_generic, impl_via_array};
 use crate::Exhaust;
 
+// -------------------------------------------------------------------------------------------------
+
 macro_rules! impl_nonzero {
-    ($t:ty, $nzt:ty) => {
-        paste! {
-            impl Exhaust for num::$nzt {
-                type Iter = [< Exhaust $nzt >];
+    ($t:ty) => {
+        impl Exhaust for NonZero<$t> {
+            type Iter = ExhaustNonZero<$t, NonZero<$t>>;
 
-                fn exhaust_factories() -> Self::Iter {
-                    [< Exhaust $nzt >] ($t::exhaust_factories().filter_map(num::$nzt::new))
-                }
-
-                crate::patterns::factory_is_self!();
+            fn exhaust_factories() -> Self::Iter {
+                // TODO: This `filter_map()` is tidy and generic, but is probably not the optimal
+                // implementation for unsigned numbers, since if `next()` is not inlined, it'll
+                // need a comparison with zero on each iteration. But I haven’t checked.
+                ExhaustNonZero::<$t, NonZero<$t>>(
+                    <$t>::exhaust_factories().filter_map(NonZero::new),
+                )
             }
 
-            #[doc = concat!("Iterator implementation of `", stringify!($nzt), "::exhaust()`.")]
-            // TODO: This should just be a type_alias_impl_trait for FilterMap when that's stable.
-            #[derive(Clone, Debug)]
-            pub struct [< Exhaust $nzt >](iter::FilterMap<<$t as Exhaust>::Iter, fn($t) -> Option<num::$nzt>>);
-
-            impl Iterator for [< Exhaust $nzt >] {
-                type Item = num::$nzt;
-
-                fn next(&mut self) -> Option<Self::Item> {
-                    self.0.next()
-                }
-            }
-            impl iter::FusedIterator for [< Exhaust $nzt >] {}
+            crate::patterns::factory_is_self!();
         }
-    }
+    };
 }
 
-impl_nonzero!(i8, NonZeroI8);
-impl_nonzero!(i16, NonZeroI16);
-impl_nonzero!(i32, NonZeroI32);
-impl_nonzero!(u8, NonZeroU8);
-impl_nonzero!(u16, NonZeroU16);
-impl_nonzero!(u32, NonZeroU32);
+// Implement `Exhaust` for all `NonZero`-able numbers that are no larger than 32 bits.
+// This should match <https://doc.rust-lang.org/std/num/trait.ZeroablePrimitive.html>
+// (as long as that's the unstable trait backing `NonZero`), except for those that are too large.
+impl_nonzero!(i8);
+impl_nonzero!(i16);
+impl_nonzero!(i32);
+impl_nonzero!(u8);
+impl_nonzero!(u16);
+impl_nonzero!(u32);
+
+/// Iterator implementation for `NonZero::exhaust()`.
+// TODO: This should just be a type_alias_impl_trait for FilterMap when that's stable.
+// Right now, it's just public-in-private so unnameable that way.
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+#[allow(clippy::type_complexity)]
+pub struct ExhaustNonZero<T: Exhaust, N>(
+    iter::FilterMap<<T as Exhaust>::Iter, fn(<T as Exhaust>::Factory) -> Option<N>>,
+);
+
+impl<T: Exhaust, N> Iterator for ExhaustNonZero<T, N> {
+    type Item = N;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+impl<T: Exhaust, N> iter::FusedIterator for ExhaustNonZero<T, N> {}
+
+// -------------------------------------------------------------------------------------------------
 
 impl_via_array!(
     num::FpCategory,


### PR DESCRIPTION
[`paste`](https://crates.io/crates/paste) has been given an “unmaintained” advisory and that means, [regardless of whether it is still any good](https://github.com/rustsec/advisory-db/pull/2215#issuecomment-2709315704), people will get warnings for having it in their transitive dependencies. I would like to avoid that.

Luckily, it turns out that we can just replace all of the token pasting with generic code. (Rust 1.79 added the `num::NonZero<T>` generic type, too, but that isn’t actually helping us because the `ZeroablePrimitive` trait it depends on is still unstable — so we still need to define separate concrete implementations.)

If a need for `paste`-like functionality comes up again, we can consider adding the functionality to our own `exhaust-macros`, look at what alternatives have developed by then, or see whether the RustSec policy has gained more nuance about “unmaintained” vs “done” status. But for now, this is one fewer dependency, quite cheaply, and less fuss.