### PR TITLE
Prepare release v0.2.4 and add precautions against careless version bumping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.3 (2025-08-24)
+## 0.2.4 (2025-08-25)
 
 ### Added
 
@@ -17,6 +17,10 @@
 ### Fixed
 
 * `derive(Exhaust)` will no longer produce spurious warnings when the type of a field is uninhabited.
+
+## 0.2.3 (2025-08-24)
+
+This release was published erroneously and is functionally equivalent to 0.2.2.
 
 ## 0.2.2 (2025-03-08)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,16 @@ members = [
     "exhaust-macros",
     "xtask",
 ]
+# Setting default-members to enclude `exhaust-macros` ensures we won't accidentally forget to
+# `cargo publish` the macro package...
+default-members = [
+    ".",
+    "exhaust-macros",
+]
 
 [package]
 name = "exhaust"
-version = "0.2.3"
+version = "0.2.4" # When bumping this don't forget the relationship with the macro package!
 edition = "2021"
 rust-version = "1.80.0"
 description = "Trait and derive macro for working with all possible values of a type (exhaustive enumeration)."
@@ -33,7 +39,7 @@ name = "keyed_collections"
 required-features = ["alloc"]
 
 [dependencies]
-exhaust-macros = { version = "0.2.1", path = "exhaust-macros" }
+exhaust-macros = { version = "0.2.4", path = "exhaust-macros" }
 # itertools is used for its powerset iterator, which is only available with alloc
 itertools = { workspace = true, optional = true }
 mutants = "0.0.3"

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exhaust-macros"
-version = "0.2.2"
+version = "0.2.4"
 edition = "2021"
 description = "Proc-macro support for the 'exhaust' library."
 repository = "https://github.com/kpreid/exhaust/"


### PR DESCRIPTION
When releasing v0.2.3 I completely forgot about the actually important part — versioning and publishing of the macro package. Adding `default-members` will prevent me from making that mistake again.