### PR TITLE
Polish derive documentation, particularly `factory_is_self`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 * The derive macro now supports a configuration attribute `#[exhaust(factory_is_self)]`,
   which disables generation of a separate `Exhaust::Factory` type.
-  This can be used to simplify the macro-generated code when the type being derived on
-  implements `Clone` and `Debug`.
+  This can be used to simplify the macro-generated code to improve build performance,
+  but has particular requirements; see the derive macro’s documentation for details.
 
 ## 0.2.4 (2025-08-25)
 

--- a/src/impls/core_sync.rs
+++ b/src/impls/core_sync.rs
@@ -11,13 +11,11 @@ macro_rules! impl_atomic {
         }
     };
 }
-use impl_atomic;
 
 #[rustfmt::skip]
 mod atomic_impl {
     use core::sync::atomic;
     use crate::Exhaust;
-    use super::impl_atomic;
 
     #[cfg(target_has_atomic = "8")]  impl_atomic!(bool, AtomicBool);
     #[cfg(target_has_atomic = "8")]  impl_atomic!(i8, AtomicI8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,14 +293,20 @@ pub trait Exhaust: Sized {
 ///
 /// # Applicability
 ///
-/// This macro may be applied to `struct`s and `enum`s, but not `union`s.
-/// All fields must have types which themselves implement [`Exhaust`].
+/// This macro can be used when:
+///
+/// * The type is a `struct` or `enum` (not a `union`).
+/// * All fields implement [`Exhaust`].
+/// * The type **does not have any invariants** other than the intrinsic one that its fields
+///   are properly initialized.
 ///
 /// <div class="warning">
 ///
 /// If your type has invariants enforced through private fields, then do not use this derive macro,
-/// as that would make it possible to obtain instances with any values whatsoever.
-/// There is not currently any way to add constraints.
+/// as that would make it possible to obtain instances with any values whatsoever
+/// (similar to implementing a deserialization trait).
+/// There is not currently any way to add constraints that reduce the possible values of fields
+/// or relate fields to each other.
 ///
 /// </div>
 ///
@@ -312,11 +318,22 @@ pub trait Exhaust: Sized {
 /// * `#[exhaust(factory_is_self)]`
 ///
 ///   Makes the `<Self as Exhaust>::Factory` associated type be `Self` instead of a newly
-///   generated type. This allows the macro to generate less code, but is a public API change.
-///   It can only be done when:
+///   generated type. This allows the macro to generate less code, but requires that:
 ///
 ///   * The type implements [`Clone`] and [`fmt::Debug`].
 ///   * All of its fields *also* implement `Exhaust<Factory = Self>`.
+///     This is the case for all primitive types such as `bool` and `i32`, but is not generally
+///     guaranteed to be true for any other implementation.
+///
+///   We recommend that you use `factory_is_self` primarily for fieldless enums and types that
+///   contain them, that you fully control.
+///
+///   ```
+///   # use exhaust::Exhaust;
+///   #[derive(Clone, Debug, Exhaust)]
+///   #[exhaust(factory_is_self)]
+///   enum ExampleOfFactoryIsSelf { One, Two }
+///   ```
 ///
 /// # Generated code
 ///


### PR DESCRIPTION
* List applicability as bullet points.
* In the warning about invariants, mention that this problem is similar to deriving deserialization traits.
* Add syntax example of `factory_is_self`.
* Warn about overusing `factory_is_self`.
* Also fix a new-on-nightly dead code warning.