### PR TITLE
Add special case when deriving for 1 field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   This can be used to simplify the macro-generated code to improve build performance,
   but has particular requirements; see the derive macro’s documentation for details.
 
+### Changed
+
+* `derive(Exhaust)` generates smaller iterators for structs or enum variants with exactly one field.
+
 ## 0.2.4 (2025-08-25)
 
 ### Added

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -21,7 +21,7 @@ pub fn peekable_exhaust<T: Exhaust>() -> Pei<T> {
     T::exhaust_factories().peekable()
 }
 
-/// Perform “carry” within a pair of peekable iterators.
+/// Perform “carry” within a pair of iterators.
 ///
 /// That is, if `low` has no more elements, advance `high`, and replace `low`
 /// with a fresh iterator from the factory function.
@@ -50,7 +50,7 @@ pub fn peekable_exhaust<T: Exhaust>() -> Pei<T> {
 /// assert!(!carried);
 /// assert_eq!([high.peek(), low.peek()], [Some(&1), Some(&0)]);
 /// ```
-pub fn carry<I, J, F>(high: &mut Peekable<I>, low: &mut Peekable<J>, factory: F) -> bool
+pub fn carry<I, J, F>(high: &mut I, low: &mut Peekable<J>, factory: F) -> bool
 where
     I: Iterator,
     J: Iterator,

--- a/tests/deriving.rs
+++ b/tests/deriving.rs
@@ -339,7 +339,7 @@ fn enum_with_uninhabited_generic() {
 }
 
 // Test specifically newtypes (structs with exactly one field).
-// We may decide to add optimizations for this case in the future, so test it in isolation.
+// We have optimizations for this case, so test it.
 #[test]
 fn newtype_struct() {
     #[derive(Debug, exhaust::Exhaust, PartialEq)]
@@ -348,6 +348,13 @@ fn newtype_struct() {
     c::<NewtypeStruct<bool>>();
     // using FieldlessEnum as a non-factory_is_self implementation to use in our generic newtype
     c::<NewtypeStruct<FieldlessEnum>>();
+
+    // Check that the newtype's iterator is not bigger (because it is itself a newtype).
+    // (This is not technically guaranteed by Rust unless we add a `repr(transparent)`, though.)
+    std::assert_eq!(
+        p::size_of::<<NewtypeStruct<bool> as exhaust::Exhaust>::Iter>(),
+        p::size_of::<<bool as exhaust::Exhaust>::Iter>()
+    );
 }
 #[test]
 fn newtype_struct_fis() {


### PR DESCRIPTION
In this case, we don’t need peekable iterators, and can just delegate, saving the memory for the peeked value.

Note that, unlike the internal `delegate_factory_and_iter!()`, this does not delegate the whole iterator type, but still always wraps it. Doing that will require an explicit configuration by the user.