### PR TITLE
Remove superfluous parentheses from tuple impls.

### DIFF
--- a/exhaust-macros/src/lib.rs
+++ b/exhaust-macros/src/lib.rs
@@ -729,12 +729,7 @@ fn derive_exhaust_for_primitive_tuple(size: u64) -> Result<TokenStream2, syn::Er
         cloners,
         field_pats,
         advance,
-    } = exhaustion_of_fields(
-        &ctx,
-        &synthetic_fields,
-        Some(&quote! {}),
-        &ConstructorSyntax::Tuple,
-    );
+    } = exhaustion_of_fields(&ctx, &synthetic_fields, None, &ConstructorSyntax::Tuple);
     assert!(
         !state_field_decls.is_empty(),
         "derived iterator must have at least one field"


### PR DESCRIPTION
This has no significant effect, but it's 20 fewer tokens for rustc to process, so why not. Previously, the macro would generate code like

    let factory = ((crate::mh_::clone(factory_0), factory_1));

and with this change it is

    let factory = (crate::mh_::clone(factory_0), factory_1);

without the parentheses that would be a tuple-struct for the public factory type if there was a public factory type.

This was discovered by a spurious warning from Rust 1.92 beta <https://github.com/rust-lang/rust-clippy/issues/16023>, so this will also prevent that warning from showing up in CI until it is fixed by Rust beta backports.