### PR TITLE
Make `impl_via_array!` impls store a range instead of the entire array.

### DIFF
--- a/src/impls/core_cmp.rs
+++ b/src/impls/core_cmp.rs
@@ -1,8 +1,10 @@
+use core::cmp::Ordering;
+
 use crate::patterns::{impl_newtype_generic, impl_via_array};
 
 impl_newtype_generic!(T: [], core::cmp::Reverse<T>, core::cmp::Reverse);
 
 impl_via_array!(
-    core::cmp::Ordering,
-    [Self::Less, Self::Equal, Self::Greater]
+    Ordering,
+    [Ordering::Less, Ordering::Equal, Ordering::Greater]
 );

--- a/src/impls/core_num.rs
+++ b/src/impls/core_num.rs
@@ -59,11 +59,11 @@ impl<T: Exhaust, N> iter::FusedIterator for ExhaustNonZero<T, N> {}
 impl_via_array!(
     num::FpCategory,
     [
-        Self::Nan,
-        Self::Infinite,
-        Self::Zero,
-        Self::Subnormal,
-        Self::Normal,
+        num::FpCategory::Nan,
+        num::FpCategory::Infinite,
+        num::FpCategory::Zero,
+        num::FpCategory::Subnormal,
+        num::FpCategory::Normal,
     ]
 );
 

--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -163,9 +163,18 @@ mod sync {
 
     impl_via_array!(
         sync::mpsc::RecvTimeoutError,
-        [Self::Timeout, Self::Disconnected]
+        [
+            sync::mpsc::RecvTimeoutError::Timeout,
+            sync::mpsc::RecvTimeoutError::Disconnected
+        ]
     );
-    impl_via_array!(sync::mpsc::TryRecvError, [Self::Empty, Self::Disconnected]);
+    impl_via_array!(
+        sync::mpsc::TryRecvError,
+        [
+            sync::mpsc::TryRecvError::Empty,
+            sync::mpsc::TryRecvError::Disconnected
+        ]
+    );
     impl_singleton!([], sync::mpsc::RecvError, sync::mpsc::RecvError);
     impl<T: Exhaust> Exhaust for sync::mpsc::TrySendError<T> {
         delegate_factory_and_iter!(remote::TrySendError<T>);

--- a/tests/core_impls.rs
+++ b/tests/core_impls.rs
@@ -8,11 +8,13 @@ use helper::{check, check_double};
 #[test]
 fn impl_unit() {
     check_double(vec![()]);
+    assert_eq!(size_of_val(&<()>::exhaust()), 1);
 }
 
 #[test]
 fn impl_single_element_tuple() {
     check_double(vec![(false,), (true,)]);
+    assert_eq!(size_of_val(&<(bool,)>::exhaust()), 1);
 }
 
 #[test]
@@ -27,12 +29,15 @@ fn impl_nontrivial_tuple() {
         (true, true, false),
         (true, true, true),
     ]);
+    // Size is 3 inner iterators + 3 peeking states. (Would be nice to be smaller.)
+    assert_eq!(size_of_val(&<(bool, bool, bool)>::exhaust()), 6);
 }
 
 #[test]
 fn impl_phantom_data() {
     use core::marker::PhantomData;
     check_double::<PhantomData<bool>>(vec![PhantomData]);
+    assert_eq!(size_of_val(&<PhantomData<bool>>::exhaust()), 1);
 }
 
 /// [`core::convert::Infallible`] is not especially interesting in its role as an error type,
@@ -40,11 +45,13 @@ fn impl_phantom_data() {
 #[test]
 fn impl_infallible() {
     check_double(Vec::<core::convert::Infallible>::new());
+    assert_eq!(size_of_val(&core::convert::Infallible::exhaust()), 0);
 }
 
 #[test]
 fn impl_bool() {
     check_double(vec![false, true]);
+    assert_eq!(size_of_val(&<bool>::exhaust()), 1);
 }
 
 #[test]
@@ -142,14 +149,23 @@ fn impl_array_of_3() {
 }
 
 #[test]
+fn impl_ordering() {
+    use core::cmp::Ordering;
+    check(vec![Ordering::Less, Ordering::Equal, Ordering::Greater]);
+    assert_eq!(size_of_val(&Ordering::exhaust()), 2);
+}
+
+#[test]
 fn impl_option() {
     check(vec![None, Some(false), Some(true)]);
+    assert_eq!(size_of_val(&<Option<bool>>::exhaust()), 1);
 }
 
 #[test]
 fn impl_poll() {
     use core::task::Poll;
     check(vec![Poll::Pending, Poll::Ready(false), Poll::Ready(true)]);
+    assert_eq!(size_of_val(&<Poll<bool>>::exhaust()), 1);
 }
 
 #[test]


### PR DESCRIPTION
This avoids wasting memory on potentially very many copies of the array, and uses 2 bytes for start and end indices instead. (This is still less compact than the dedicated `bool` iterator because it has to store the start and end as separate bytes.) Also:

* Each iterator is now a private-in-public opaque type instead of an `array::IntoIter`. The factory types remain `Self`.
* Added some tests of sizes of the iterators (not only `impl_via_array` ones).