### PR TITLE
Don’t require `factory_is_self` recursively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * The derive macro now supports a configuration attribute `#[exhaust(factory_is_self)]`,
   which disables generation of a separate `Exhaust::Factory` type.
   This can be used to simplify the macro-generated code to improve build performance,
-  but has particular requirements; see the derive macro’s documentation for details.
+  but requires the type and its fields to implement `Clone` and `Debug`,
+  similar to what was required in `exhaust` v0.1;
+  see the derive macro’s documentation for details.
 
 ### Changed
 

--- a/exhaust-macros/src/fields.rs
+++ b/exhaust-macros/src/fields.rs
@@ -95,13 +95,37 @@ pub(crate) fn exhaustion_of_fields(
                 factory_state_expr
             };
 
+            let (type_of_field_iterator, init_of_field_iterator): (syn::Type, syn::Expr) = if ctx
+                .factory_is_self()
+            {
+                // If factory_is_self, then the iterator we store is an iterator over the
+                // values of the field type instead of the factories of the field type.
+                (
+                    syn::parse_quote! { #crate_path::Iter<#field_type> },
+                    syn::parse_quote! { #helpers::default() },
+                )
+            } else {
+                (
+                    syn::parse_quote! { <#field_type as #crate_path::Exhaust>::Iter },
+                    syn::parse_quote! { <#field_type as #crate_path::Exhaust>::exhaust_factories() },
+                )
+            };
+
             return ExhaustFields {
-                state_field_decls: syn::Fields::Unnamed(
-                    syn::parse_quote! { (<#field_type as #crate_path::Exhaust>::Iter) },
-                ),
+                state_field_decls: syn::Fields::Unnamed(syn::FieldsUnnamed {
+                    paren_token: Default::default(),
+                    unnamed: Punctuated::from_iter([syn::Field {
+                        attrs: Vec::new(),
+                        vis: syn::Visibility::Inherited,
+                        mutability: syn::FieldMutability::None,
+                        ident: None,
+                        colon_token: None,
+                        ty: type_of_field_iterator,
+                    }]),
+                }),
                 factory_field_decls,
                 initializers: quote! {
-                    0: <#field_type as #crate_path::Exhaust>::exhaust_factories()
+                    0: #init_of_field_iterator
                 },
                 cloners: quote! {
                     0: ::core::clone::Clone::clone(#field_iter_var)
@@ -116,22 +140,22 @@ pub(crate) fn exhaustion_of_fields(
             };
         }
 
-        2.. => { /* fall rthrough to general case */ }
+        2.. => { /* fall through to general case */ }
     }
 
     #[allow(clippy::type_complexity)]
     let (
         iterator_state_fields,
         iterator_fields_init,
+        field_iterator_init_exprs,
         iterator_fields_clone,
         iter_field_names,
         target_field_names,
-        field_types,
         factory_value_vars,
     ): (
         Punctuated<syn::Field, syn::Token![,]>,
         Vec<TokenStream2>,
-        Vec<TokenStream2>,
+        Vec<syn::Expr>,
         Vec<TokenStream2>,
         Vec<TokenStream2>,
         Vec<TokenStream2>,
@@ -164,6 +188,22 @@ pub(crate) fn exhaustion_of_fields(
 
         let field_type = &field.ty;
 
+        let (type_of_field_iterator, field_iter_init_function): (syn::Type, syn::Expr) =
+            if ctx.factory_is_self() {
+                // If factory_is_self, then the iterators we store are iterators over the
+                // values of the field type instead of the factories of the field type.
+                (
+                    syn::parse_quote! { #helpers::Pv<#field_type> },
+                    syn::parse_quote! { #helpers::pv_iter::<#field_type> },
+                )
+            } else {
+                // TODO: The first field’s iterator doesn't need to be peekable.
+                (
+                    syn::parse_quote! { #helpers::Pf<#field_type> },
+                    syn::parse_quote! { #helpers::pf_iter::<#field_type> },
+                )
+            };
+
         (
             syn::Field {
                 attrs: Vec::new(),
@@ -171,17 +211,17 @@ pub(crate) fn exhaustion_of_fields(
                 mutability: syn::FieldMutability::None,
                 ident: Some(iter_field_name.clone()),
                 colon_token: None,
-                ty: syn::parse_quote! { #crate_path::iteration::Pei<#field_type> },
+                ty: type_of_field_iterator,
             },
             quote! {
-                #iter_field_name : #crate_path::iteration::peekable_exhaust::<#field_type>()
+                #iter_field_name : #field_iter_init_function()
             },
+            field_iter_init_function,
             quote! {
                 #iter_field_name : #helpers::clone(#iter_field_name)
             },
             iter_field_name.to_token_stream(),
             target_field_name,
-            field_type.clone().to_token_stream(),
             factory_var_name,
         )
     }));
@@ -224,17 +264,11 @@ pub(crate) fn exhaustion_of_fields(
             iter_field_names
                 .iter()
                 .skip(1)
-                .zip(field_types.iter().skip(1)),
+                .zip(field_iterator_init_exprs.iter().skip(1)),
         )
         .rev()
-        .map(|(high, (low, low_field_type))| {
-            quote! {
-                #crate_path::iteration::carry(
-                    #high,
-                    #low,
-                    #crate_path::iteration::peekable_exhaust::<#low_field_type>
-                )
-            }
+        .map(|(high, (low, low_init_function))| {
+            quote! { #crate_path::iteration::carry(#high, #low, #low_init_function) }
         })
         // && short circuiting gives us the behavior we want conveniently, whereas
         // the nearest alternative would be to define a separate function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,13 +323,9 @@ pub trait Exhaust: Sized {
 ///   Makes the `<Self as Exhaust>::Factory` associated type be `Self` instead of a newly
 ///   generated type. This allows the macro to generate less code, but requires that:
 ///
-///   * The type implements [`Clone`] and [`fmt::Debug`].
-///   * All of its fields *also* implement `Exhaust<Factory = Self>`.
-///     This is the case for all primitive types such as `bool` and `i32`, but is not generally
-///     guaranteed to be true for any other implementation.
-///
-///   We recommend that you use `factory_is_self` primarily for fieldless enums and types that
-///   contain them, that you fully control.
+///   * The type implements [`Clone`] and [`fmt::Debug`] (so that it is a valid factory type).
+///   * All of its fields implement [`Clone`] and [`fmt::Debug`]
+///     (so that they can be part of the iterator state).
 ///
 ///   ```
 ///   # use exhaust::Exhaust;

--- a/src/mh_.rs
+++ b/src/mh_.rs
@@ -2,7 +2,7 @@
 //! name hygiene and for concise output.
 
 pub use core::fmt;
-pub use core::iter::{FusedIterator, Iterator};
+pub use core::iter::{FusedIterator, Iterator, Peekable};
 pub use {Clone, Default, None, Option, Some};
 
 /// Convenience trait-alias for helping the derive macro be simpler and generate simpler code.
@@ -26,6 +26,21 @@ pub fn next<I: Iterator>(iterator: &mut I) -> Option<I::Item> {
 pub fn clone<T: Clone>(original: &T) -> T {
     original.clone()
 }
-pub fn peek<I: Iterator>(iter: &mut core::iter::Peekable<I>) -> Option<&I::Item> {
+pub fn peek<I: Iterator>(iter: &mut Peekable<I>) -> Option<&I::Item> {
     iter.peek()
+}
+
+/// Peekable iterator over factories of `T`.
+pub type Pf<T> = Peekable<<T as crate::Exhaust>::Iter>;
+/// Peekable iterator over values of `T`.
+pub type Pv<T> = Peekable<crate::Iter<T>>;
+
+/// Constructs [`Pf`].
+pub fn pf_iter<T: crate::Exhaust>() -> Pf<T> {
+    T::exhaust_factories().peekable()
+}
+
+/// Constructs [`Pv`].
+pub fn pv_iter<T: crate::Exhaust>() -> Pv<T> {
+    crate::Iter::<T>::default().peekable()
 }

--- a/tests/deriving.rs
+++ b/tests/deriving.rs
@@ -37,6 +37,12 @@ where
 
 fn assert_factory_is_self<T: exhaust::Exhaust<Factory = T>>() {}
 
+/// Helper struct that implements `Exhaust`, *not* in the `factory_is_self` way, but meets the
+/// requirements to be a field of a `factory_is_self` type — in particular, it is `Clone`.
+/// This struct is not itself a test case.
+#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+struct NotFis;
+
 #[derive(Debug, exhaust::Exhaust, PartialEq)]
 struct UnitStruct;
 
@@ -120,15 +126,17 @@ fn struct_simple_fis() {
     struct SimpleStructFis {
         a: bool,
         b: bool,
+        not_fis: NotFis,
     }
 
+    #[cfg_attr(any(), rustfmt::skip)]
     std::assert_eq!(
         c::<SimpleStructFis>(),
         std::vec![
-            SimpleStructFis { a: false, b: false },
-            SimpleStructFis { a: false, b: true },
-            SimpleStructFis { a: true, b: false },
-            SimpleStructFis { a: true, b: true },
+            SimpleStructFis { not_fis: NotFis, a: false, b: false },
+            SimpleStructFis { not_fis: NotFis, a: false, b: true },
+            SimpleStructFis { not_fis: NotFis, a: true, b: false },
+            SimpleStructFis { not_fis: NotFis, a: true, b: true },
         ]
     );
     assert_factory_is_self::<SimpleStructFis>();
@@ -164,15 +172,17 @@ fn struct_generic_and_fis() {
     struct GenericFis<T: std::marker::Copy> {
         a: T,
         b: T,
+        not_fis: NotFis,
     }
 
+    #[cfg_attr(any(), rustfmt::skip)]
     std::assert_eq!(
         c::<GenericFis<bool>>(),
         std::vec![
-            GenericFis { a: false, b: false },
-            GenericFis { a: false, b: true },
-            GenericFis { a: true, b: false },
-            GenericFis { a: true, b: true },
+            GenericFis { not_fis: NotFis, a: false, b: false },
+            GenericFis { not_fis: NotFis, a: false, b: true },
+            GenericFis { not_fis: NotFis, a: true, b: false },
+            GenericFis { not_fis: NotFis, a: true, b: true },
         ]
     );
     assert_factory_is_self::<GenericFis<bool>>();
@@ -259,7 +269,7 @@ enum EnumWithFields {
 #[exhaust(factory_is_self)]
 enum EnumWithFieldsFis {
     Foo(bool, bool),
-    Bar(bool),
+    Bar(bool, NotFis),
 }
 
 #[test]
@@ -272,7 +282,7 @@ fn enum_fields() {
             EnumWithFields::Foo(true, false),
             EnumWithFields::Foo(true, true),
             EnumWithFields::Bar(false),
-            EnumWithFields::Bar(true)
+            EnumWithFields::Bar(true),
         ]
     );
 }
@@ -285,8 +295,8 @@ fn enum_fields_fis() {
             EnumWithFieldsFis::Foo(false, true),
             EnumWithFieldsFis::Foo(true, false),
             EnumWithFieldsFis::Foo(true, true),
-            EnumWithFieldsFis::Bar(false),
-            EnumWithFieldsFis::Bar(true)
+            EnumWithFieldsFis::Bar(false, NotFis),
+            EnumWithFieldsFis::Bar(true, NotFis),
         ]
     );
     assert_factory_is_self::<EnumWithFieldsFis>();


### PR DESCRIPTION
Fixes #99.

This change allows `factory_is_self` to be used even if the fields’ types are not themselves `factory_is_self`, as long as they are `Clone`.

This also reduces the number of items the macro uses from the `iteration` module. I could have instead added the new by-value items to `iteration` instead of the macro helpers module, but that didn’t feel like good API design. I may want to remove `iteration` entirely.