### PR TITLE
Remove `Factory = Self` bound from derived type parameter bounds.

### DIFF
--- a/exhaust-macros/src/common.rs
+++ b/exhaust-macros/src/common.rs
@@ -82,8 +82,7 @@ impl ExhaustContext {
         let mut path;
         if self.factory_is_self() {
             path = self.helpers();
-            path.segments
-                .push(parse_quote! { ExhaustWithFactoryEqSelf });
+            path.segments.push(parse_quote! { ExhaustAndFactoryish });
         } else {
             path = self.exhaust_crate_path.clone();
             path.segments.push(parse_quote! { Exhaust });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,8 @@ pub trait Exhaust: Sized {
 ///
 /// * The type is a `struct` or `enum` (not a `union`).
 /// * All fields implement [`Exhaust`].
+/// * All type parameters are used directly.
+///   (That is, `struct Foo<T>(T);` rather than `struct Foo<T: Trait>(T::Assoc);`.)
 /// * The type **does not have any invariants** other than the intrinsic one that its fields
 ///   are properly initialized.
 ///

--- a/src/mh_.rs
+++ b/src/mh_.rs
@@ -6,14 +6,15 @@ pub use core::iter::{FusedIterator, Iterator, Peekable};
 pub use core::primitive::usize;
 pub use {Clone, Default, None, Option, Some};
 
-/// Convenience trait-alias for helping the derive macro be simpler and generate simpler code.
+/// Types which are valid as fields of `Exhaust<Factory = Self>` implementations.
+/// Such types must both implement [`Exhaust`] and also the traits required of a factory type,
+/// i.e. `Clone + fmt::Debug`
 ///
-/// It includes `Clone + fmt::Debug` because those are the bounds required of factories,
-/// and including them as supertrait bounds here allows avoiding reiterating them.
+/// This trait alias helps the derive macro be simpler and generate simpler code.
 #[doc(hidden)]
-pub trait ExhaustWithFactoryEqSelf: crate::Exhaust<Factory = Self> + Clone + fmt::Debug {}
+pub trait ExhaustAndFactoryish: crate::Exhaust + Clone + fmt::Debug {}
 
-impl<T> ExhaustWithFactoryEqSelf for T where T: crate::Exhaust<Factory = T> + Clone + fmt::Debug {}
+impl<T> ExhaustAndFactoryish for T where T: crate::Exhaust + Clone + fmt::Debug {}
 
 // Trait methods cannot be `use`d, so define alias functions for them
 #[must_use]

--- a/tests/deriving.rs
+++ b/tests/deriving.rs
@@ -47,7 +47,7 @@ fn assert_factory_is_self<T: exhaust::Exhaust<Factory = T>>() {}
 /// Helper struct that implements `Exhaust`, *not* in the `factory_is_self` way, but meets the
 /// requirements to be a field of a `factory_is_self` type — in particular, it is `Clone`.
 /// This struct is not itself a test case.
-#[derive(Clone, Debug, exhaust::Exhaust, PartialEq)]
+#[derive(Clone, Copy, Debug, exhaust::Exhaust, PartialEq)]
 struct NotFis;
 
 #[derive(Debug, exhaust::Exhaust, PartialEq)]
@@ -205,6 +205,16 @@ fn struct_generic_and_fis() {
         ]
     );
     assert_factory_is_self::<GenericFis<bool>>();
+
+    // A generic factory_is_self type can still be used with parameters that aren't factory_is_self.
+    std::assert_eq!(
+        c::<GenericFis<NotFis>>(),
+        [GenericFis {
+            not_fis: NotFis,
+            a: NotFis,
+            b: NotFis
+        }]
+    );
 }
 
 #[derive(Debug, exhaust::Exhaust, PartialEq)]
@@ -431,6 +441,9 @@ fn newtype_struct_fis() {
     struct NewtypeStructFis<T>(T);
 
     c::<NewtypeStructFis<bool>>();
+
+    // A generic factory_is_self type can still be used with parameters that aren't factory_is_self.
+    std::assert_eq!(c::<NewtypeStructFis<NotFis>>(), [NewtypeStructFis(NotFis)]);
 }
 
 mod module {


### PR DESCRIPTION
Continuation of #100.

This bound was left over from the previous design where it was required, and it meant that the requirements on generic parameters were stronger than what was required of non-generic field types. Now we only require `Exhaust + Clone + Debug` so that maximum flexibility is available.

Also, documented the fact that the derive macro won’t work in situations involving associated types and such. (Could use better wording.)