### PR TITLE
Prepare release v0.2.5 and improve packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.5 (2026-03-14)
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ default-members = [
     "exhaust-macros",
 ]
 
+[workspace.package]
+edition = "2021"
+rust-version = "1.80.0"
+repository = "https://github.com/kpreid/exhaust/"
+license = "MIT OR Apache-2.0"
+
 [package]
 name = "exhaust"
 # When bumping this don't forget the relationship with the macro package!
@@ -19,11 +25,11 @@ name = "exhaust"
 # do decide to release `exhaust` v0.3, we will be able to keep the major version of `exhaust-macros`
 # the same — or just switch to v0.4 if that feels cleaner.
 version = "0.2.5"
-edition = "2021"
-rust-version = "1.80.0"
+edition.workspace = true
+rust-version.workspace = true
 description = "Trait and derive macro for working with all possible values of a type (exhaustive enumeration)."
-repository = "https://github.com/kpreid/exhaust/"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 categories = ["algorithms", "rust-patterns", "no-std"]
 keywords = ["exhaustive"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ repository.workspace = true
 license.workspace = true
 categories = ["algorithms", "rust-patterns", "no-std"]
 keywords = ["exhaustive"]
+include = ["*.rs", "README.md", "CHANGELOG.md", "LICENSE*"]
 
 [features]
 default = ["std"]

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -12,6 +12,7 @@ include = ["*.rs", "README.md"]
 proc-macro = true
 
 [dependencies]
+# TODO: Remove itertools dependency when MSRV ≥ 1.85 and we can use FromIterator on tuples
 itertools = { workspace = true }
 proc-macro2 = "1.0.86"
 quote = "1.0.37"

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "exhaust-macros"
 version = "0.3.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 description = "Proc-macro support for the 'exhaust' library. Do not use this library directly."
-repository = "https://github.com/kpreid/exhaust/"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 description = "Proc-macro support for the 'exhaust' library. Do not use this library directly."
 repository.workspace = true
 license.workspace = true
+include = ["*.rs", "README.md"]
 
 [lib]
 proc-macro = true

--- a/exhaust-macros/LICENSE-APACHE
+++ b/exhaust-macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/exhaust-macros/LICENSE-MIT
+++ b/exhaust-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/exhaust-macros/README.md
+++ b/exhaust-macros/README.md
@@ -1,0 +1,2 @@
+This macro package is intended for use by [`exhaust`](https://crates.io/crates/exhaust).
+**Do not depend on it directly** — this may cause dependency resolution failures.


### PR DESCRIPTION
* Put 0.2.5 version and date in CHANGELOG header.
* Use workspace inheritance.
* Add README and LICENSE files to `exhaust-macros`.
* Add `package.include` to manifest so that we don’t include unneeded files.
* Note that we want to remove the `itertools` dependency.