### PR TITLE
Fix bounds of `impl FusedIterator for FlatZipMap`.

### DIFF
--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -113,8 +113,7 @@ where
 
 impl<I, J, O> Iterator for FlatZipMap<I, J, O>
 where
-    I: Iterator,
-    I::Item: Clone,
+    I: Iterator<Item: Clone>,
     J: Iterator,
 {
     type Item = O;
@@ -143,8 +142,9 @@ where
 
 impl<I, J, O> iter::FusedIterator for FlatZipMap<I, J, O>
 where
-    I: Iterator,
-    I::Item: Clone,
-    J: Iterator,
+    I: iter::FusedIterator<Item: Clone>,
+    // This bound is not necessary in the current implementation,
+    // but there isn’t any point to not requiring it.
+    J: iter::FusedIterator,
 {
 }


### PR DESCRIPTION
`FlatZipMap` does not behave as a fused iterator when the outer iterator is not fused.

This is arguably a semver breaking change, but `FlatZipMap` cannot be constructed with user-provided types and is `#[doc(hidden)]`.

Also changed the `Clone` bounds to use associated type bound syntax. This is within our MSRV of 1.80.0 because it was added in 1.79.0.