### PR TITLE
Miscellaneous polish.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ default = ["std"]
 std = ["alloc"]
 alloc = ["dep:itertools"]
 
+[lib]
+test = false # all tests are external / integration tests
+
 [[test]]
 name = "alloc_impls"
 required-features = ["alloc"]

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -11,6 +11,13 @@ include = ["*.rs", "README.md"]
 [lib]
 proc-macro = true
 
+# all tests are in other packages (though we might someday add tests of the internal helpers)
+test = false
+
+# macro documentation is located in the `exhaust` package
+doc = false
+doctest = false
+
 [dependencies]
 # TODO: Remove itertools dependency when MSRV ≥ 1.85 and we can use FromIterator on tuples
 itertools = { workspace = true }

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -119,23 +119,22 @@ where
     type Item = O;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // This must loop because each outer iterator item could produce an inner iterator with
+        // any number of items, including zero.
         loop {
-            match self.inner {
-                Some((ref i_item, ref mut j_iter)) => {
-                    if let Some(j_item) = j_iter.next() {
-                        return Some((self.output_fn)(i_item.clone(), j_item));
-                    }
-                    // If no items, try the outer iter.
-                    self.inner = None;
+            // Try to produce an item using the current inner iterator.
+            if let Some((ref i_item, ref mut j_iter)) = self.inner {
+                if let Some(j_item) = j_iter.next() {
+                    return Some((self.output_fn)(i_item.clone(), j_item));
                 }
-                None => match self.outer_iterator.next() {
-                    Some(i_item) => {
-                        let j_iter = (self.iter_fn)(&i_item);
-                        self.inner = Some((i_item, j_iter));
-                    }
-                    None => return None,
-                },
+                // If no items, drop this inner iter and try the outer iter.
+                self.inner = None;
             }
+
+            // Advance the outer iterator to produce a new inner iterator.
+            let i_item = self.outer_iterator.next()?;
+            let j_iter = (self.iter_fn)(&i_item);
+            self.inner = Some((i_item, j_iter));
         }
     }
 }

--- a/tests/core_impls_and_misc/core_impls.rs
+++ b/tests/core_impls_and_misc/core_impls.rs
@@ -1,9 +1,12 @@
-use core::{fmt, num, ops};
+//! Tests of implementations of [`Exhaust`] for [`core`] types.
+
+use core::fmt;
+use core::num;
+use core::ops;
 
 use exhaust::Exhaust;
 
-mod helper;
-use helper::{check, check_double};
+use crate::helper::{check, check_double};
 
 #[test]
 fn impl_unit() {
@@ -280,26 +283,5 @@ mod impl_ops {
     #[test]
     fn impl_range_to_inclusive() {
         check(vec![..=false, ..=true]);
-    }
-}
-
-/// Tests of `exhaust::Iter`, which isn't strictly an impl for crate core, but doesn't need its
-/// own test target.
-mod iter {
-    #[test]
-    fn size_hint_and_len() {
-        let it = exhaust::Iter::<bool>::default();
-        assert_eq!(it.size_hint(), (2, Some(2)));
-        assert_eq!(it.len(), 2);
-    }
-
-    #[test]
-    fn clone() {
-        let mut it1 = exhaust::Iter::<bool>::default();
-        assert_eq!(it1.next(), Some(false));
-        let mut it2 = it1.clone();
-
-        assert_eq!(it2.len(), 1);
-        assert_eq!(it2.next(), Some(true));
     }
 }

--- a/tests/core_impls_and_misc/iter.rs
+++ b/tests/core_impls_and_misc/iter.rs
@@ -1,0 +1,18 @@
+//! Tests of [`exhaust::Iter`].
+
+#[test]
+fn size_hint_and_len() {
+    let it = exhaust::Iter::<bool>::default();
+    assert_eq!(it.size_hint(), (2, Some(2)));
+    assert_eq!(it.len(), 2);
+}
+
+#[test]
+fn clone() {
+    let mut it1 = exhaust::Iter::<bool>::default();
+    assert_eq!(it1.next(), Some(false));
+    let mut it2 = it1.clone();
+
+    assert_eq!(it2.len(), 1);
+    assert_eq!(it2.next(), Some(true));
+}

--- a/tests/core_impls_and_misc/main.rs
+++ b/tests/core_impls_and_misc/main.rs
@@ -1,0 +1,5 @@
+#[path = "../helper/mod.rs"]
+mod helper;
+
+mod core_impls;
+mod iter;


### PR DESCRIPTION
* Make `core_impls` test target multi-file. This makes a better place for tests that aren't about `Exhaust` impls.
* Disable some unnecessary Cargo target operations (testing and documenting)
* Polish code of `FlatZipMap`. This fixes a new Clippy warning.
