### PR TITLE
Better iterator for `NonZero<u*>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,19 @@
 ### Added
 
 * Iterators for several standard library enums now implement `ExactSizeIterator`.
-* `NonZero` iterators now have an improved but not perfect `size_hint()`.
-* `exhaust::Iter` now forwards `nth()`, `nth_back()`, and `last()` to the underlying iterator,
-  which may improve performance.
+* Iterators for `NonZero<u*>` now implement `DoubleEndedIterator` and `ExactSizeIterator`.
 
 ### Fixed
 
 * Corrected incorrect bounds on a `FusedIterator` implementation.
   (It is not possible to obtain a misbehaving value of this undocumented type, but this change could
   technically cause some code to stop compiling.)
+
+### Performance improvements
+
+* Iterators for `NonZero<u*>` have been simplified.
+* Iterators for `NonZero<i*>` now have an improved but not perfect `size_hint()`.
+* `exhaust::Iter` now forwards `nth()`, `nth_back()`, and `last()` to the underlying iterator.
 
 ## 0.2.5 (2026-03-14)
 

--- a/src/impls/core_num.rs
+++ b/src/impls/core_num.rs
@@ -1,51 +1,89 @@
 use core::iter;
 use core::num::{self, NonZero};
+use core::ops::RangeInclusive;
 
-use crate::patterns::{impl_newtype_generic, impl_via_array};
+use crate::patterns::{
+    factory_is_self, impl_iterator_for_newtype, impl_newtype_generic, impl_via_array,
+};
 use crate::Exhaust;
 
 // -------------------------------------------------------------------------------------------------
 
-macro_rules! impl_nonzero {
+macro_rules! impl_nonzero_signed {
     ($t:ty) => {
         impl Exhaust for NonZero<$t> {
-            type Iter = ExhaustNonZero<$t, NonZero<$t>>;
+            // TODO: Use a better iterator implementation that does not need to check each element
+            // for being zero.
+            type Iter = ExhaustNonZeroSigned<$t, NonZero<$t>>;
 
             fn exhaust_factories() -> Self::Iter {
-                // TODO: This `filter_map()` is tidy and generic, but is probably not the optimal
-                // implementation for unsigned numbers, since if `next()` is not inlined, it'll
-                // need a comparison with zero on each iteration. But I haven’t checked.
-                ExhaustNonZero::<$t, NonZero<$t>>(
+                ExhaustNonZeroSigned::<$t, NonZero<$t>>(
                     <$t>::exhaust_factories().filter_map(NonZero::new),
                 )
             }
 
-            crate::patterns::factory_is_self!();
+            factory_is_self!();
         }
+    };
+}
+
+macro_rules! impl_nonzero_unsigned {
+    ($t:ty) => {
+        impl Exhaust for NonZero<$t> {
+            // TODO: Once MSRV ≥ Rust 1.96, replace this with
+            // type Iter = core::range::RangeInclusiveIter<NonZero<$t>>;
+            type Iter = ExhaustNonZeroUnsigned<$t>;
+
+            fn exhaust_factories() -> Self::Iter {
+                const { ExhaustNonZeroUnsigned(1..=<$t>::MAX) }
+            }
+
+            factory_is_self!();
+        }
+
+        // This impl can’t be generic because we can’t name the T: ZeroablePrimitive bound
+        // which NonZero<T> requires.
+        const _: () = {
+            fn nonzero_or_panic(value: $t) -> NonZero<$t> {
+                match NonZero::try_from(value) {
+                    Ok(nz) => nz,
+                    Err(_) => unreachable!(),
+                }
+            }
+
+            impl_iterator_for_newtype!([] for ExhaustNonZeroUnsigned<$t> {
+                type Item = NonZero<$t>;
+                fn mapper = nonzero_or_panic;
+                double_ended_where [];
+            });
+            impl iter::FusedIterator for ExhaustNonZeroUnsigned<$t> {}
+            impl iter::ExactSizeIterator for ExhaustNonZeroUnsigned<$t> {}
+        };
     };
 }
 
 // Implement `Exhaust` for all `NonZero`-able numbers that are no larger than 32 bits.
 // This should match <https://doc.rust-lang.org/std/num/trait.ZeroablePrimitive.html>
 // (as long as that's the unstable trait backing `NonZero`), except for those that are too large.
-impl_nonzero!(i8);
-impl_nonzero!(i16);
-impl_nonzero!(i32);
-impl_nonzero!(u8);
-impl_nonzero!(u16);
-impl_nonzero!(u32);
+impl_nonzero_signed!(i8);
+impl_nonzero_signed!(i16);
+impl_nonzero_signed!(i32);
+impl_nonzero_unsigned!(u8);
+impl_nonzero_unsigned!(u16);
+impl_nonzero_unsigned!(u32);
 
-/// Iterator implementation for `NonZero::exhaust()`.
+/// Iterator implementation for `NonZero::exhaust()` on signed integers.
+//---
 // TODO: This should just be a type_alias_impl_trait for FilterMap when that's stable.
 // Right now, it's just public-in-private so unnameable that way.
 #[derive(Clone, Debug)]
 #[doc(hidden)]
 #[allow(clippy::type_complexity)]
-pub struct ExhaustNonZero<T: Exhaust, N>(
+pub struct ExhaustNonZeroSigned<T: Exhaust, N>(
     iter::FilterMap<<T as Exhaust>::Iter, fn(<T as Exhaust>::Factory) -> Option<N>>,
 );
 
-impl<T: Exhaust, N> Iterator for ExhaustNonZero<T, N> {
+impl<T: Exhaust, N> Iterator for ExhaustNonZeroSigned<T, N> {
     type Item = N;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -65,7 +103,16 @@ impl<T: Exhaust, N> Iterator for ExhaustNonZero<T, N> {
         (lower, upper)
     }
 }
-impl<T: Exhaust, N> iter::FusedIterator for ExhaustNonZero<T, N> {}
+impl<T: Exhaust, N> iter::FusedIterator for ExhaustNonZeroSigned<T, N> {}
+
+/// Iterator implementation for `NonZero::exhaust()` on unsigned integers.
+//---
+// Note: the `Iterator` implementations are in the `impl_nonzero_unsigned!` macro.
+//
+// TODO: Once MSRV ≥ Rust 1.96, replace this entirely with RangeInclusiveIter<NonZero<$t>>.
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+pub struct ExhaustNonZeroUnsigned<T>(RangeInclusive<T>);
 
 // -------------------------------------------------------------------------------------------------
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,60 +389,11 @@ impl<T: Exhaust> Default for Iter<T> {
     }
 }
 
-impl<T: Exhaust> Iterator for Iter<T> {
+patterns::impl_iterator_for_newtype!([T: Exhaust] for Iter<T> {
     type Item = T;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(T::from_factory)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
-
-    fn fold<B, F>(self, init: B, mut f: F) -> B
-    where
-        Self: Sized,
-        F: FnMut(B, Self::Item) -> B,
-    {
-        self.0.fold(init, |state, item_factory| {
-            f(state, T::from_factory(item_factory))
-        })
-    }
-
-    // Ideally we would forward `try_fold()`, but that is not possible until the `Try` trait
-    // is stabilized.
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth(n).map(T::from_factory)
-    }
-
-    fn last(self) -> Option<Self::Item> {
-        self.0.last().map(T::from_factory)
-    }
-}
-
-impl<T: Exhaust<Iter: DoubleEndedIterator>> DoubleEndedIterator for Iter<T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(T::from_factory)
-    }
-
-    fn rfold<B, F>(self, init: B, mut f: F) -> B
-    where
-        Self: Sized,
-        F: FnMut(B, Self::Item) -> B,
-    {
-        self.0.rfold(init, |state, item_factory| {
-            f(state, T::from_factory(item_factory))
-        })
-    }
-
-    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.0.nth_back(n).map(T::from_factory)
-    }
-}
+    fn mapper = T::from_factory;
+    double_ended_where [T: Exhaust<Iter: DoubleEndedIterator>];
+});
 
 impl<T: Exhaust> FusedIterator for Iter<T> {
     // Note: This is only correct because of the `FusedIterator` bound on `Exhaust::Iter`.

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -166,3 +166,75 @@ macro_rules! impl_newtype_generic {
     };
 }
 pub(crate) use impl_newtype_generic;
+
+/// Implement [`Iterator`] and [`DoubleEndedIterator`] for a newtype
+/// to forward to its `.0` field and call a function to map each item.
+///
+/// The function expression will be evaluated at each call site,
+/// so a named function should be preferred over a closure.
+macro_rules! impl_iterator_for_newtype {
+    (
+        [$($generics:tt)*] for $iterator_type:ty {
+            type Item = $item_type:ty;
+            fn mapper = $mapping_function:expr;
+            double_ended_where [$($double_ended_bounds:tt)*];
+        }
+    ) => {
+        impl<$($generics)*> Iterator for $iterator_type {
+            type Item = $item_type;
+
+            #[inline]
+            fn next(&mut self) -> Option<Self::Item> {
+                self.0.next().map($mapping_function)
+            }
+
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.0.size_hint()
+            }
+
+            fn fold<B, F>(self, init: B, mut f: F) -> B
+            where
+                Self: Sized,
+                F: FnMut(B, Self::Item) -> B,
+            {
+                self.0.fold(init, |state, inner_item| {
+                    f(state, ($mapping_function)(inner_item))
+                })
+            }
+
+            // Ideally we would forward `try_fold()`, but that is not possible until the `Try` trait
+            // is stabilized.
+
+            fn nth(&mut self, n: usize) -> Option<Self::Item> {
+                self.0.nth(n).map($mapping_function)
+            }
+
+            fn last(self) -> Option<Self::Item> {
+                self.0.last().map($mapping_function)
+            }
+        }
+
+        impl<$($generics)*> DoubleEndedIterator for $iterator_type
+        where $($double_ended_bounds)* {
+            fn next_back(&mut self) -> Option<Self::Item> {
+                self.0.next_back().map($mapping_function)
+            }
+
+            fn rfold<B, F>(self, init: B, mut f: F) -> B
+            where
+                Self: Sized,
+                F: FnMut(B, Self::Item) -> B,
+            {
+                self.0.rfold(init, |state, inner_item| {
+                    f(state, ($mapping_function)(inner_item))
+                })
+            }
+
+            fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+                self.0.nth_back(n).map($mapping_function)
+            }
+        }
+    };
+}
+pub(crate) use impl_iterator_for_newtype;

--- a/tests/core_impls_and_misc/core_impls.rs
+++ b/tests/core_impls_and_misc/core_impls.rs
@@ -89,8 +89,8 @@ fn impl_char() {
 
 #[test]
 fn impl_nonzero_unsigned() {
-    // The non-u8 impls are macro-generated the same way.
-    check(
+    // The non-u8 impls are macro-generated the same way as this one.
+    check_double_exact(
         (1..=255)
             .map(|i| num::NonZeroU8::new(i).unwrap())
             .collect::<Vec<num::NonZeroU8>>(),
@@ -99,7 +99,7 @@ fn impl_nonzero_unsigned() {
 
 #[test]
 fn impl_nonzero_signed() {
-    // The non-i8 impls are macro-generated the same way.
+    // The non-i8 impls are macro-generated the same way as this one.
     check(
         (-128..=127)
             .filter_map(num::NonZeroI8::new)


### PR DESCRIPTION
Instead of removing zero via `filter_map()`, use a range iterator that is set to the appropriate range. This is still not ideal because each value construction is checked, but it should be able to optimize better, and it can be `ExactSizeIterator`.

We can improve on this after MSRV ≥ 1.96.