### PR TITLE
Reimplement powerset iterator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ### Fixed
 
+* Iterators for `BTreeSet` and `HashSet` now produce their elements (sets) in the order that is
+  sorted according to `BTreeSet`’s `Ord` implementation, rather than producing the sets in order
+  from smallest to largest.
+  This follows the general recommendation for all `Exhaust` implementations.
+  (`BTreeMap`’s and `HashMap`’s ordering have also changed, but it is not yet the case that
+  `BTreeMap` exhaustion occurs in sorted order.)
 * Corrected incorrect bounds on a `FusedIterator` implementation.
   (It is not possible to obtain a misbehaving value of this undocumented type, but this change could
   technically cause some code to stop compiling.)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ required-features = ["alloc"]
 # It’s OK to use an "=" version requirement here because this should be the *only* package that
 # depends on `exhaust-macros`, so a dependency resolution conflict will not arise.
 exhaust-macros = { version = "=0.3.0", path = "exhaust-macros" }
-# itertools is used for its powerset iterator, which is only available with alloc
+# we use itertools::{MultiProduct, repeat_n} for collections
 itertools = { workspace = true, optional = true }
 mutants = ">=0.0.1, <0.0.5"
 

--- a/src/impls/alloc_impls.rs
+++ b/src/impls/alloc_impls.rs
@@ -10,9 +10,11 @@ use alloc::vec::Vec;
 
 use itertools::Itertools as _;
 
-use crate::iteration::peekable_exhaust;
+use crate::iteration::{peekable_exhaust, Pei};
 use crate::patterns::{delegate_factory_and_iter, impl_newtype_generic};
 use crate::Exhaust;
+
+// -------------------------------------------------------------------------------------------------
 
 impl_newtype_generic!(T: [], Box<T>, Box::new);
 impl_newtype_generic!(T: [], Rc<T>, Rc::new);
@@ -43,26 +45,93 @@ impl<T: Exhaust + Ord> Exhaust for BTreeSet<T> {
     }
 }
 
-// TODO: Instead of delegating to itertools, we should implement our own powerset
-// iterator, to provide the preferred ordering of elements.
-pub struct ExhaustSet<T: Exhaust>(itertools::Powerset<<T as Exhaust>::Iter>);
+// -------------------------------------------------------------------------------------------------
+
+/// Iterator which exhausts set types, in sorted order if `T::exhaust()` is sorted.
+pub struct ExhaustSet<T: Exhaust> {
+    /// The next elements of these iterators are all but one of the elements of the next set to be
+    /// produced (unless `self.last` is exhausted, in which case we will start backtracking).
+    ///
+    /// Exception: In the case of the empty set, this is empty, since it can't have -1 elements
+    /// as the above rule would otherwise imply.
+    list: Vec<Pei<T>>,
+
+    /// If `None`, we should produce the empty set (as the first element).
+    /// Otherwise, contains an iterator whose next item is the greatest element of `T` that the
+    /// next set produced whose other elements are in `list` will contain.
+    ///
+    /// This iterator is exhausted when we are backtracking (in which case `self.list` is
+    /// non-empty) or when we have produced every set (in which case `self.list` is empty).
+    last: Option<Pei<T>>,
+}
 
 impl<T: Exhaust> Default for ExhaustSet<T> {
     fn default() -> Self {
-        ExhaustSet(itertools::Itertools::powerset(T::exhaust_factories()))
+        ExhaustSet {
+            list: Vec::new(),
+            last: None,
+        }
     }
 }
 
 impl<T: Exhaust> Clone for ExhaustSet<T> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            list: self.list.clone(),
+            last: self.last.clone(),
+        }
     }
 }
 
 impl<T: Exhaust> Iterator for ExhaustSet<T> {
     type Item = Vec<T::Factory>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
+        let Some(ref mut last_iter) = self.last else {
+            // Initial state; time to produce the set with 0 elements, and
+            // set up to produce a set with 1 element after this one.
+            self.last = Some(peekable_exhaust::<T>());
+            return Some(Vec::new());
+        };
+
+        loop {
+            return if let Some(elem) = last_iter.peek() {
+                let item = Vec::from_iter(
+                    self.list
+                        .iter_mut()
+                        .map(|iter| {
+                            iter.peek()
+                                .expect("no peekable should be exhausted")
+                                .clone()
+                        })
+                        .chain(iter::once(elem.clone())),
+                );
+
+                // Start iterating over sets that are 1 element longer than this one,
+                // if there are any.
+                self.list.push(last_iter.clone());
+
+                // Now that we’ve grabbed the clone we need for self.list, actually advance
+                // the iterator in self.last (we only peeked before).
+                last_iter.next();
+
+                Some(item)
+            } else {
+                // self.last is exhausted.
+                // This means there are no more sets of length self.list.len() + 1
+                // with the prefix currently stored in self.list.
+                // Advance the iterator in self.list and make it the new self.last.
+                if let Some(mut new_last) = self.list.pop() {
+                    _ = new_last.next();
+                    *last_iter = new_last;
+                    // TODO: can we express this algorithm without a loop?
+                    continue;
+                } else {
+                    // No more sets at all.
+                    // Keep the exhausted iterator as a marker to stop (so we're fused).
+                    None
+                }
+            };
+        }
     }
 }
 impl<T: Exhaust> FusedIterator for ExhaustSet<T> {}
@@ -73,9 +142,15 @@ where
     T::Iter: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ExhaustSet").field(&self.0).finish()
+        let Self { list, last } = self;
+        f.debug_struct("ExhaustSet")
+            .field("list", &list)
+            .field("last", &last)
+            .finish()
     }
 }
+
+// -------------------------------------------------------------------------------------------------
 
 pub(crate) type MapFactory<K, V> = Vec<(<K as Exhaust>::Factory, <V as Exhaust>::Factory)>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,11 @@
 #![warn(clippy::exhaustive_enums)]
 #![warn(clippy::exhaustive_structs)]
 #![warn(clippy::pedantic)]
+#![allow(
+    // disagree with these readability opinions
+    clippy::redundant_else,
+    clippy::from_iter_instead_of_collect,
+)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/tests/keyed_collections.rs
+++ b/tests/keyed_collections.rs
@@ -5,19 +5,55 @@
 extern crate alloc;
 use alloc::collections::{BTreeMap, BTreeSet};
 
-#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use exhaust::Exhaust;
 
 mod helper;
 use helper::check;
 
+/// Test [`BTreeSet`] (and the internal `ExhaustSet` algorithm) on [`bool`], a type with 2 values.
 #[test]
-fn impl_btreeset() {
+fn impl_btreeset_2() {
     check::<BTreeSet<bool>>(vec![
         BTreeSet::from_iter([]),
         BTreeSet::from_iter([false]),
-        BTreeSet::from_iter([true]),
         BTreeSet::from_iter([false, true]),
+        BTreeSet::from_iter([true]),
+    ]);
+}
+
+/// Test [`BTreeSet`] (and the internal `ExhaustSet` algorithm) on an element type with 4 values,
+/// and thus 2⁴ = 16 sets.
+///
+/// We don’t do this for `HashSet` because this test is to better exercise the internal algorithm,
+/// which is shared between both set types.
+#[test]
+fn impl_btreeset_4() {
+    #[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Exhaust)]
+    enum Four {
+        A,
+        B,
+        C,
+        D,
+    }
+    use Four::*;
+
+    check::<BTreeSet<Four>>(vec![
+        BTreeSet::from_iter([]),
+        BTreeSet::from_iter([A]),
+        BTreeSet::from_iter([A, B]),
+        BTreeSet::from_iter([A, B, C]),
+        BTreeSet::from_iter([A, B, C, D]),
+        BTreeSet::from_iter([A, B, D]),
+        BTreeSet::from_iter([A, C]),
+        BTreeSet::from_iter([A, C, D]),
+        BTreeSet::from_iter([A, D]),
+        BTreeSet::from_iter([B]),
+        BTreeSet::from_iter([B, C]),
+        BTreeSet::from_iter([B, C, D]),
+        BTreeSet::from_iter([B, D]),
+        BTreeSet::from_iter([C]),
+        BTreeSet::from_iter([C, D]),
+        BTreeSet::from_iter([D]),
     ]);
 }
 
@@ -25,28 +61,27 @@ fn impl_btreeset() {
 #[test]
 fn impl_hashset() {
     use std::collections::HashSet;
-    // TODO: This is not the preferred element ordering; [false, true] should be
-    // before [true], as per lexicographic ordering. Fixing that will require
-    // implementing our own powerset iterator.
     check::<HashSet<bool>>(vec![
         HashSet::from_iter([]),
         HashSet::from_iter([false]),
-        HashSet::from_iter([true]),
         HashSet::from_iter([false, true]),
+        HashSet::from_iter([true]),
     ]);
 }
 
+/// The complex shape of an exhaustive list of sets only once, used twice.
 fn bool_maps() -> Vec<BTreeMap<bool, bool>> {
+    // TODO: This list (and the iterator it is testing) should be sorted, but is not.
     vec![
         BTreeMap::from_iter([]),
         BTreeMap::from_iter([(false, false)]),
         BTreeMap::from_iter([(false, true)]),
-        BTreeMap::from_iter([(true, false)]),
-        BTreeMap::from_iter([(true, true)]),
         BTreeMap::from_iter([(false, false), (true, false)]),
         BTreeMap::from_iter([(false, false), (true, true)]),
         BTreeMap::from_iter([(false, true), (true, false)]),
         BTreeMap::from_iter([(false, true), (true, true)]),
+        BTreeMap::from_iter([(true, false)]),
+        BTreeMap::from_iter([(true, true)]),
     ]
 }
 


### PR DESCRIPTION
This fixes <https://github.com/kpreid/exhaust/issues/106> by producing sets in sorted order (provided that the element iterator does).