### PR TITLE
Add a wrapper type for `io::Cursor` iterator.

### DIFF
--- a/src/impls/std_impls.rs
+++ b/src/impls/std_impls.rs
@@ -1,11 +1,12 @@
 #![allow(clippy::wildcard_imports)]
 
+use core::convert::identity;
 use core::pin::Pin;
 use core::{fmt, iter};
 
 use crate::iteration::{peekable_exhaust, FlatZipMap};
 use crate::patterns::{
-    delegate_factory_and_iter, factory_is_self, impl_newtype_generic, impl_singleton,
+    self, delegate_factory_and_iter, factory_is_self, impl_newtype_generic, impl_singleton,
     impl_via_array,
 };
 use crate::Exhaust;
@@ -66,9 +67,9 @@ mod io {
     /// Produces each combination of a buffer state and a cursor position, except for those
     /// where the position is beyond the end of the buffer.
     impl<T: Exhaust + AsRef<[u8]> + Clone + fmt::Debug> Exhaust for io::Cursor<T> {
-        type Iter = FlatZipMap<crate::Iter<T>, core::ops::RangeInclusive<u64>, io::Cursor<T>>;
+        type Iter = ExhaustCursor<T>;
         fn exhaust_factories() -> Self::Iter {
-            FlatZipMap::new(
+            ExhaustCursor(FlatZipMap::new(
                 T::exhaust(),
                 |buf| 0..=(buf.as_ref().len() as u64),
                 |buf, pos| {
@@ -76,10 +77,23 @@ mod io {
                     cursor.set_position(pos);
                     cursor
                 },
-            )
+            ))
         }
         factory_is_self!();
     }
+
+    /// Iterator for [`io::Cursor`] values.
+    #[doc(hidden)] // public to satisfy the compiler, but not actually nameable except via associated type
+    #[derive(Clone, Debug)]
+    pub struct ExhaustCursor<T: Exhaust>(
+        FlatZipMap<crate::Iter<T>, core::ops::RangeInclusive<u64>, io::Cursor<T>>,
+    );
+    patterns::impl_iterator_for_newtype!([T: Exhaust + AsRef<[u8]> + Clone + fmt::Debug] for ExhaustCursor<T> {
+        type Item = io::Cursor<T>;
+        fn mapper = identity;
+        not_double_ended;
+    });
+    impl<T: Exhaust + AsRef<[u8]> + Clone + fmt::Debug> iter::FusedIterator for ExhaustCursor<T> {}
 
     impl<T: io::Read + Exhaust> Exhaust for io::BufReader<T> {
         delegate_factory_and_iter!(T);

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -68,7 +68,7 @@ where
 /// Given an iterator and a function of its elements that yields an iterator,
 /// produce tuples of the two iterators' results.
 #[derive(Clone)]
-#[doc(hidden)] // Public because exposed as an iterator type. Not yet recommended for use.
+#[doc(hidden)] // Public because it was formerly exposed as an iterator type. Not yet recommended for use.
 pub struct FlatZipMap<I: Iterator, J: Iterator, O> {
     outer_iterator: I,
     inner: Option<(I::Item, J)>,

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -180,6 +180,40 @@ macro_rules! impl_iterator_for_newtype {
             double_ended_where [$($double_ended_bounds:tt)*];
         }
     ) => {
+        $crate::patterns::impl_iterator_for_newtype!([$($generics)*] for $iterator_type {
+            type Item = $item_type;
+            fn mapper = $mapping_function;
+            not_double_ended;
+        });
+
+        impl<$($generics)*> DoubleEndedIterator for $iterator_type
+        where $($double_ended_bounds)* {
+            fn next_back(&mut self) -> Option<Self::Item> {
+                self.0.next_back().map($mapping_function)
+            }
+
+            fn rfold<B, F>(self, init: B, mut f: F) -> B
+            where
+                Self: Sized,
+                F: FnMut(B, Self::Item) -> B,
+            {
+                self.0.rfold(init, |state, inner_item| {
+                    f(state, ($mapping_function)(inner_item))
+                })
+            }
+
+            fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+                self.0.nth_back(n).map($mapping_function)
+            }
+        }
+    };
+    (
+        [$($generics:tt)*] for $iterator_type:ty {
+            type Item = $item_type:ty;
+            fn mapper = $mapping_function:expr;
+            not_double_ended;
+        }
+    ) => {
         impl<$($generics)*> Iterator for $iterator_type {
             type Item = $item_type;
 
@@ -212,27 +246,6 @@ macro_rules! impl_iterator_for_newtype {
 
             fn last(self) -> Option<Self::Item> {
                 self.0.last().map($mapping_function)
-            }
-        }
-
-        impl<$($generics)*> DoubleEndedIterator for $iterator_type
-        where $($double_ended_bounds)* {
-            fn next_back(&mut self) -> Option<Self::Item> {
-                self.0.next_back().map($mapping_function)
-            }
-
-            fn rfold<B, F>(self, init: B, mut f: F) -> B
-            where
-                Self: Sized,
-                F: FnMut(B, Self::Item) -> B,
-            {
-                self.0.rfold(init, |state, inner_item| {
-                    f(state, ($mapping_function)(inner_item))
-                })
-            }
-
-            fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-                self.0.nth_back(n).map($mapping_function)
             }
         }
     };


### PR DESCRIPTION
Closes #2. (I don’t think the remaining possible additions of wrappers are worth doing.)