### PR TITLE
Add `impl Exhaust for core::num::Saturating`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* `impl Exhaust for core::num::Saturating`
 * Iterators for several standard library enums now implement `ExactSizeIterator`.
 * Iterators for `NonZero<u*>` now implement `DoubleEndedIterator` and `ExactSizeIterator`.
 

--- a/src/impls/core_num.rs
+++ b/src/impls/core_num.rs
@@ -127,4 +127,5 @@ impl_via_array!(
     ]
 );
 
+impl_newtype_generic!(T: [], num::Saturating<T>, num::Saturating);
 impl_newtype_generic!(T: [], num::Wrapping<T>, num::Wrapping);

--- a/tests/core_impls_and_misc/core_impls.rs
+++ b/tests/core_impls_and_misc/core_impls.rs
@@ -246,6 +246,26 @@ mod impl_fmt {
     }
 }
 
+mod impl_num {
+    use super::*;
+
+    #[test]
+    fn impl_saturating() {
+        use core::num::Saturating;
+        // While using Saturating with Bool doesn’t make much sense, it is sufficient to
+        // exercise exhaustion, since the struct has just the one public field.
+        check_double_exact(vec![Saturating(false), Saturating(true)]);
+    }
+
+    #[test]
+    fn impl_wrapping() {
+        use core::num::Wrapping;
+        // While using Wrapping with Bool doesn’t make much sense, it is sufficient to
+        // exercise exhaustion, since the struct has just the one public field.
+        check_double_exact(vec![Wrapping(false), Wrapping(true)]);
+    }
+}
+
 mod impl_ops {
     use super::*;
 


### PR DESCRIPTION
This standard library type was stabilized in 1.74.0.