### PR TITLE
Prepare release v0.2.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.6 (2026-05-07)
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "exhaust"
 # This version has started using "=" version requirements for `exhaust-macros`, so when we
 # do decide to release `exhaust` v0.3, we will be able to keep the major version of `exhaust-macros`
 # the same — or just switch to v0.4 if that feels cleaner.
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 rust-version.workspace = true
 description = "Trait and derive macro for working with all possible values of a type (exhaustive enumeration)."


### PR DESCRIPTION
This release needs no changes to `exhaust-macros`. (In the repository, there is a change to add `lib.test = false`, but there is no practical need to release that change.)