### PR TITLE
Allow `itertools` version 0.15 and avoid it in `exhaust-macros`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.7 (2026-06-17)
+
+* The dependency on `itertools` can now use version 0.15, in addition to versions 0.13 through 0.14.
+  This has no effect on the functionality of `exhaust`.
+
 ## 0.2.6 (2026-05-07)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2.7 (2026-06-17)
 
+### Performance improvements
+
+* The `exhaust-macros` package no longer depends on `itertools`.
+  This may improve build parallelism, and if cross-compiling, avoids building `itertools` for the
+  host as well as the target.
 * The dependency on `itertools` can now use version 0.15, in addition to versions 0.13 through 0.14.
   This has no effect on the functionality of `exhaust`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "exhaust"
 # This version has started using "=" version requirements for `exhaust-macros`, so when we
 # do decide to release `exhaust` v0.3, we will be able to keep the major version of `exhaust-macros`
 # the same — or just switch to v0.4 if that feels cleaner.
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 rust-version.workspace = true
 description = "Trait and derive macro for working with all possible values of a type (exhaustive enumeration)."
@@ -57,7 +57,7 @@ required-features = ["alloc"]
 [dependencies]
 # It’s OK to use an "=" version requirement here because this should be the *only* package that
 # depends on `exhaust-macros`, so a dependency resolution conflict will not arise.
-exhaust-macros = { version = "=0.3.0", path = "exhaust-macros" }
+exhaust-macros = { version = "=0.3.1", path = "exhaust-macros" }
 # we use itertools::{MultiProduct, repeat_n} for collections
 itertools = { workspace = true, optional = true }
 mutants = ">=0.0.1, <0.0.5"
@@ -65,9 +65,12 @@ mutants = ">=0.0.1, <0.0.5"
 [workspace.dependencies]
 # Minimum version of `itertools` is 0.13.0 because we need this bug fixed,
 #   <https://github.com/rust-itertools/itertools/issues/337>,
-# which affects `ExhaustMap`. 0.14 is the current latest version, which contains no breaking
-# changes relevant to our usages: according to the changelog,
+# which affects `ExhaustMap`. 0.15 is the current latest version, which contains no breaking
+# changes relevant to our usages: according to the changelog, 0.14 changes
 #   * Increased MSRV to 1.63.0
 #   * Removed generic parameter from cons_tuples
-# neither of which affects us.
-itertools = { version = ">=0.13.0, <0.15", default-features = false, features = ["use_alloc"] }
+# and 0.15 changes
+#   * Restructure `Position` as struct instead of enum
+#   * Canonicalize `all_equal_value`'s error type
+# none of which affects us.
+itertools = { version = ">=0.13.0, <0.16", default-features = false, features = ["use_alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,14 +55,12 @@ name = "keyed_collections"
 required-features = ["alloc"]
 
 [dependencies]
+
 # It’s OK to use an "=" version requirement here because this should be the *only* package that
 # depends on `exhaust-macros`, so a dependency resolution conflict will not arise.
 exhaust-macros = { version = "=0.3.1", path = "exhaust-macros" }
-# we use itertools::{MultiProduct, repeat_n} for collections
-itertools = { workspace = true, optional = true }
-mutants = ">=0.0.1, <0.0.5"
 
-[workspace.dependencies]
+# We use itertools::{MultiProduct, repeat_n} for collections.
 # Minimum version of `itertools` is 0.13.0 because we need this bug fixed,
 #   <https://github.com/rust-itertools/itertools/issues/337>,
 # which affects `ExhaustMap`. 0.15 is the current latest version, which contains no breaking
@@ -73,4 +71,8 @@ mutants = ">=0.0.1, <0.0.5"
 #   * Restructure `Position` as struct instead of enum
 #   * Canonicalize `all_equal_value`'s error type
 # none of which affects us.
-itertools = { version = ">=0.13.0, <0.16", default-features = false, features = ["use_alloc"] }
+itertools = { version = ">=0.13.0, <0.16", optional = true, default-features = false, features = ["use_alloc"] }
+
+# When <https://rust-lang.github.io/rfcs/3808-register-tool.html> is stable, we can use it instead
+# of this.
+mutants = ">=0.0.1, <0.0.5"

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exhaust-macros"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Proc-macro support for the 'exhaust' library. Do not use this library directly."

--- a/exhaust-macros/Cargo.toml
+++ b/exhaust-macros/Cargo.toml
@@ -19,8 +19,6 @@ doc = false
 doctest = false
 
 [dependencies]
-# TODO: Remove itertools dependency when MSRV ≥ 1.85 and we can use FromIterator on tuples
-itertools = { workspace = true }
 proc-macro2 = "1.0.86"
 quote = "1.0.37"
 syn = { version = "2.0.73", features = ["full"] }

--- a/exhaust-macros/src/fields.rs
+++ b/exhaust-macros/src/fields.rs
@@ -3,6 +3,7 @@ use quote::{quote, ToTokens as _};
 use syn::punctuated::Punctuated;
 
 use crate::common::{ConstructorSyntax, ExhaustContext};
+use crate::iter_util::unzip7;
 
 /// Pieces of the implementation of a product iterator, over fields of a struct
 /// or enum variant.
@@ -151,7 +152,6 @@ pub(crate) fn exhaustion_of_fields(
         2.. => { /* fall through to general case */ }
     }
 
-    #[allow(clippy::type_complexity)]
     let (
         iterator_state_fields,
         iterator_fields_init,
@@ -168,7 +168,7 @@ pub(crate) fn exhaustion_of_fields(
         Vec<TokenStream2>,
         Vec<TokenStream2>,
         Vec<TokenStream2>,
-    ) = itertools::multiunzip(struct_fields.iter().enumerate().map(|(index, field)| {
+    ) = unzip7(struct_fields.iter().enumerate().map(|(index, field)| {
         let target_field_name = match &field.ident {
             Some(name) => name.to_token_stream(),
             None => syn::LitInt::new(&format!("{index}"), Span::mixed_site()).to_token_stream(),

--- a/exhaust-macros/src/iter_util.rs
+++ b/exhaust-macros/src/iter_util.rs
@@ -1,0 +1,92 @@
+//! Iteration helpers; basically a tiny replacement for `itertools` to minimize build-time
+//! dependencies.
+
+/// Merge 5 iterators into an iterator of 5-element tuples.
+pub(crate) fn zip5<I1, I2, I3, I4, I5>(
+    it1: I1,
+    it2: I2,
+    it3: I3,
+    it4: I4,
+    it5: I5,
+) -> impl Iterator<Item = (I1::Item, I2::Item, I3::Item, I4::Item, I5::Item)>
+where
+    I1: IntoIterator,
+    I2: IntoIterator,
+    I3: IntoIterator,
+    I4: IntoIterator,
+    I5: IntoIterator,
+{
+    it1.into_iter()
+        .zip(it2)
+        .zip(it3)
+        .zip(it4)
+        .zip(it5)
+        .map(|((((i1, i2), i3), i4), i5)| (i1, i2, i3, i4, i5))
+}
+
+/// Collect 6-element tuples into 6 containers.
+#[must_use]
+pub(crate) fn unzip6<T1, T2, T3, T4, T5, T6, C1, C2, C3, C4, C5, C6>(
+    iterator: impl Iterator<Item = (T1, T2, T3, T4, T5, T6)>,
+) -> (C1, C2, C3, C4, C5, C6)
+where
+    C1: Default + Extend<T1>,
+    C2: Default + Extend<T2>,
+    C3: Default + Extend<T3>,
+    C4: Default + Extend<T4>,
+    C5: Default + Extend<T5>,
+    C6: Default + Extend<T6>,
+{
+    let mut c1 = C1::default();
+    let mut c2 = C2::default();
+    let mut c3 = C3::default();
+    let mut c4 = C4::default();
+    let mut c5 = C5::default();
+    let mut c6 = C6::default();
+
+    iterator.for_each(|(i1, i2, i3, i4, i5, i6)| {
+        c1.extend([i1]);
+        c2.extend([i2]);
+        c3.extend([i3]);
+        c4.extend([i4]);
+        c5.extend([i5]);
+        c6.extend([i6]);
+    });
+
+    (c1, c2, c3, c4, c5, c6)
+}
+
+/// Collect 7-element tuples into 7 containers.
+#[must_use]
+pub(crate) fn unzip7<T1, T2, T3, T4, T5, T6, T7, C1, C2, C3, C4, C5, C6, C7>(
+    iterator: impl Iterator<Item = (T1, T2, T3, T4, T5, T6, T7)>,
+) -> (C1, C2, C3, C4, C5, C6, C7)
+where
+    C1: Default + Extend<T1>,
+    C2: Default + Extend<T2>,
+    C3: Default + Extend<T3>,
+    C4: Default + Extend<T4>,
+    C5: Default + Extend<T5>,
+    C6: Default + Extend<T6>,
+    C7: Default + Extend<T7>,
+{
+    let mut c1 = C1::default();
+    let mut c2 = C2::default();
+    let mut c3 = C3::default();
+    let mut c4 = C4::default();
+    let mut c5 = C5::default();
+    let mut c6 = C6::default();
+    let mut c7 = C7::default();
+
+    iterator.for_each(|(i1, i2, i3, i4, i5, i6, i7)| {
+        c1.extend([i1]);
+        c2.extend([i2]);
+        c3.extend([i3]);
+        c4.extend([i4]);
+        c5.extend([i5]);
+        c6.extend([i6]);
+        c7.extend([i7]);
+    });
+
+    (c1, c2, c3, c4, c5, c6, c7)
+}

--- a/exhaust-macros/src/lib.rs
+++ b/exhaust-macros/src/lib.rs
@@ -1,9 +1,10 @@
 //! Proc-macro support for the `exhaust` library. Do not use this library directly.
 
+#![allow(clippy::type_complexity)] // not useful signal
+
 use proc_macro::TokenStream;
 use std::iter;
 
-use itertools::izip;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens as _};
 use syn::punctuated::Punctuated;
@@ -13,12 +14,12 @@ use syn::{parse_macro_input, parse_quote, DeriveInput};
 // -------------------------------------------------------------------------------------------------
 
 mod common;
-use common::ExhaustContext;
+use common::{ConstructorSyntax, ExhaustContext};
 
 mod fields;
 use fields::{exhaustion_of_fields, ExhaustFields};
 
-use crate::common::ConstructorSyntax;
+mod iter_util;
 
 // -------------------------------------------------------------------------------------------------
 // Macro entry point functions
@@ -456,7 +457,7 @@ fn derive_exhaust_for_enum(
         Vec<TokenStream2>,
         Vec<TokenStream2>,
         Vec<TokenStream2>,
-    ) = itertools::multiunzip(e
+    ) = iter_util::unzip6(e
         .variants
         .iter()
         .zip(state_enum_progress_variants.iter())
@@ -530,7 +531,7 @@ fn derive_exhaust_for_enum(
     let first_state_variant_initializer = &state_enum_variant_initializers[0];
 
     // Match arms to advance the iterator.
-    let variant_next_arms = izip!(
+    let variant_next_arms = iter_util::zip5(
         e.variants.iter(),
         state_enum_progress_variants.iter(),
         state_enum_field_pats.iter(),
@@ -580,7 +581,7 @@ fn derive_exhaust_for_enum(
             Vec::with_capacity(state_enum_progress_variants.len() + 1);
         let mut remaining_count_so_far: usize = 0;
         for (original_enum_variant, progress_variant_name) in
-            izip!(&e.variants, &state_enum_progress_variants).rev()
+            iter::zip(&e.variants, &state_enum_progress_variants).rev()
         {
             if original_enum_variant.fields.is_empty() {
                 // If the variant is fieldless, we can predict that it has exactly 1 value to exhaust.


### PR DESCRIPTION
* Remove `itertools` dependency from `exhaust-macros` by implementing zip and unzip ourselves.

* Expand `itertools` dependency range to include the newly released version 0.15.

Fixes #107 (without even bumping MSRV).
